### PR TITLE
Themes on Mac OS X

### DIFF
--- a/src/app/mainapplication.cpp
+++ b/src/app/mainapplication.cpp
@@ -252,6 +252,14 @@ void MainApplication::loadSettings()
         cssFile.close();
     }
 #endif
+#ifdef Q_WS_MAC
+    if (QFile(m_activeThemePath + "mac.css").exists()) {
+        cssFile.setFileName(m_activeThemePath + "mac.css");
+        cssFile.open(QFile::ReadOnly);
+        css.append(cssFile.readAll());
+        cssFile.close();
+    }
+#endif
 #if defined(Q_WS_WIN) || defined(Q_OS_OS2)
     if (QFile(m_activeThemePath + "windows.css").exists()) {
         cssFile.setFileName(m_activeThemePath + "windows.css");


### PR DESCRIPTION
Now QupZilla loads only _windows.css_ or _linux.css_ theme file, so I've added a code to load _mac.css_ as well.

However, on Mac OS X I cannot see a background image behind tab widget. Here is a screenshot of Chrome theme: http://img855.imageshack.us/img855/2820/qupzillachromemac.png
Maybe it can be fixed with Qt::WA_NoSystemBackground?
