### PR TITLE
Make Preferences menu item visible on Mac OS X

### DIFF
--- a/src/app/qupzilla.cpp
+++ b/src/app/qupzilla.cpp
@@ -775,10 +775,10 @@ void QupZilla::aboutToShowToolsMenu()
     connect(m_actionPrivateBrowsing, SIGNAL(triggered(bool)), this, SLOT(startPrivate(bool)));
     m_menuTools->addAction(m_actionPrivateBrowsing);
     m_menuTools->addSeparator();
-    mApp->plugins()->populateToolsMenu(m_menuTools);
 #ifndef Q_WS_X11
     m_menuTools->addAction(QIcon(":/icons/faenza/settings.png"), tr("Pr&eferences"), this, SLOT(showPreferences()))->setShortcut(QKeySequence("Ctrl+P"));
 #endif
+    mApp->plugins()->populateToolsMenu(m_menuTools);
 }
 
 void QupZilla::aboutToShowViewMenu()


### PR DESCRIPTION
I cannot see Preferences item in Tools menu in Mac OS X, possibly due to populateToolsMenu() being invoked before addAction(). I've changed the order.
