### PR TITLE
tab order in preference dialog

### DIFF
--- a/src/preferences/preferences.ui
+++ b/src/preferences/preferences.ui
@@ -186,7 +186,7 @@
       <enum>Qt::NoFocus</enum>
      </property>
      <property name="currentIndex">
-      <number>10</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="stackedWidgetPage1">
       <layout class="QGridLayout" name="gridLayout_6">


### PR DESCRIPTION
I reworked tab order in preference dialog. Until now, it was in order You added interface elements. Now, tab should focus with next element. 
