### PR TITLE
More memory efficient and faster preview generation.

### DIFF
--- a/src/lib/webview/webtab.cpp
+++ b/src/lib/webview/webtab.cpp
@@ -264,16 +264,21 @@ QPixmap WebTab::renderTabPreview()
     renderWidth -= verticalScrollBarWidth;
     renderHeight -= horizontalScrollBarHeight;
 
-    QPixmap pageImage(renderWidth, renderHeight);
+    const int previewWidth = 230;
+    const int previewHeight = 150;
+    qreal scalingFactor = 2 * static_cast<qreal>(previewWidth) / renderWidth;
+
+    QPixmap pageImage(2 * previewWidth, 2 * previewHeight);
     pageImage.fill(Qt::transparent);
 
     QPainter p(&pageImage);
+    p.scale(scalingFactor, scalingFactor);
     m_view->page()->mainFrame()->render(&p, QWebFrame::ContentsLayer);
     p.end();
 
     page->setViewportSize(oldSize);
 
-    return pageImage.scaled(230, 150, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+    return pageImage.scaled(previewWidth, previewHeight, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 }
 
 void WebTab::showNotification(QWidget* notif)


### PR DESCRIPTION
There is no need to allocate a very large image buffer, just enough for
the thumbnail preview. For a little filtering, use the two-stage
scaling. See http://labs.qt.nokia.com/2009/01/26/creating-thumbnail-preview/
for the details.

This tecnique is adopted from my live preview implementation for Arora:
http://ariya.ofilabs.com/2008/07/be-my-mirror-my-sword-and-shield.html.
