### PR TITLE
Select downloaded file when opening its folder [Windows only]

### DIFF
--- a/src/lib/downloads/downloaditem.cpp
+++ b/src/lib/downloads/downloaditem.cpp
@@ -33,6 +33,7 @@
 #include <QFileInfo>
 #include <QMessageBox>
 #include <QDesktopServices>
+#include <QProcess>
 
 //#define DOWNMANAGER_DEBUG
 
@@ -385,7 +386,13 @@ void DownloadItem::openFile()
 
 void DownloadItem::openFolder()
 {
+#ifdef Q_WS_WIN
+    QString winFileName = m_path + m_fileName;
+    winFileName.replace("/","\\");
+    QProcess::startDetached("explorer.exe /e,/select,\""+winFileName+"\"");
+#else
     QDesktopServices::openUrl(QUrl::fromLocalFile(m_path));
+#endif
 }
 
 void DownloadItem::readyRead()


### PR DESCRIPTION
The following command:
`explorer.exe  /e,/select,"C:\Windows\system32\calc.exe"` 
opens `C:\Windows\system32` and select `calc.exe`
And `/e` is for opening `explorer.exe` in default view.

Note: if the file not found explorer opens user's home folder and select user's document folder.
