### PR TITLE
Added Drag-n-Drop functionality to bookmarkmanager and bookmarksidebar.

### DIFF
--- a/src/lib/bookmarks/bookmarksmanager.h
+++ b/src/lib/bookmarks/bookmarksmanager.h
@@ -75,6 +75,10 @@ private slots:
     void removeBookmark(const BookmarksModel::Bookmark &bookmark);
     void bookmarkEdited(const BookmarksModel::Bookmark &before, const BookmarksModel::Bookmark &after);
 
+    void changeBookmarkParent(const QString &name, const QByteArray &, int id,
+                              const QUrl &, const QString &, const QString &newParent);
+    void changeFolderParent(const QString &name, bool isSubfolder);
+
 private:
     QupZilla* getQupZilla();
 

--- a/src/lib/bookmarks/bookmarksmodel.h
+++ b/src/lib/bookmarks/bookmarksmodel.h
@@ -109,13 +109,22 @@ signals:
     void bookmarkDeleted(const BookmarksModel::Bookmark &bookmark);
     void bookmarkEdited(const BookmarksModel::Bookmark &before, const BookmarksModel::Bookmark &after);
 
+    void bookmarkParentChanged(const QString &name, const QByteArray &imageData, int id,
+                               const QUrl &url, const QString &oldParent, const QString &newParent);
+
     void folderAdded(const QString &title);
     void folderDeleted(const QString &title);
 
     void subfolderAdded(const QString &title);
     void folderRenamed(const QString &before, const QString &after);
 
+    void folderParentChanged(const QString &name, bool isSubfolder);
+
 public slots:
+    void bookmarkDropedLink(const QUrl &url, const QString &title, const QVariant &imageVariant,
+                            const QString &folder = QLatin1String("unsorted"), bool* ok = 0);
+    void changeBookmarkParent(int id, const QString &newParent, const QString &oldParent, bool* ok = 0);
+    void changeFolderParent(const QString &name, bool isSubfolder, bool* ok = 0);
 
 private:
     bool m_showMostVisited;

--- a/src/lib/bookmarks/bookmarkstoolbar.cpp
+++ b/src/lib/bookmarks/bookmarkstoolbar.cpp
@@ -60,6 +60,8 @@ BookmarksToolbar::BookmarksToolbar(QupZilla* mainClass, QWidget* parent)
     connect(m_bookmarksModel, SIGNAL(subfolderAdded(QString)), this, SLOT(subfolderAdded(QString)));
     connect(m_bookmarksModel, SIGNAL(folderDeleted(QString)), this, SLOT(folderDeleted(QString)));
     connect(m_bookmarksModel, SIGNAL(folderRenamed(QString, QString)), this, SLOT(folderRenamed(QString, QString)));
+    connect(m_bookmarksModel, SIGNAL(folderParentChanged(QString,bool)), this, SLOT(changeFolderParent(QString,bool)));
+    connect(m_bookmarksModel, SIGNAL(bookmarkParentChanged(QString,QByteArray,int,QUrl,QString,QString)), this, SLOT(changeBookmarkParent(QString,QByteArray,int,QUrl,QString,QString)));
 
     setMaximumWidth(p_QupZilla->width());
 
@@ -384,6 +386,41 @@ void BookmarksToolbar::folderRenamed(const QString &before, const QString &after
             button->menu()->setTitle(after);
             return;
         }
+    }
+}
+
+void BookmarksToolbar::changeBookmarkParent(const QString &name, const QByteArray &imageData, int id,
+                                            const QUrl &url, const QString &oldParent, const QString &newParent)
+{
+    if (oldParent != _bookmarksToolbar && newParent != _bookmarksToolbar) {
+        return;
+    }
+
+    bool itemIsAboutToRemove = (newParent != _bookmarksToolbar);
+
+    Bookmark bookmark;
+    bookmark.id =  id;
+    bookmark.url = url;
+    bookmark.title = name;
+    bookmark.folder = QLatin1String("bookmarksToolbar");
+    bookmark.image = QImage::fromData(imageData);
+    bookmark.inSubfolder = false;
+
+    if (itemIsAboutToRemove) {
+        removeBookmark(bookmark);
+    }
+    else {
+        addBookmark(bookmark);
+    }
+}
+
+void BookmarksToolbar::changeFolderParent(const QString &name, bool isSubfolder)
+{
+    if (!isSubfolder) {
+        folderDeleted(name);
+    }
+    else {
+        subfolderAdded(name);
     }
 }
 

--- a/src/lib/bookmarks/bookmarkstoolbar.h
+++ b/src/lib/bookmarks/bookmarkstoolbar.h
@@ -68,6 +68,10 @@ private slots:
     void folderDeleted(const QString &name);
     void folderRenamed(const QString &before, const QString &after);
 
+    void changeBookmarkParent(const QString &name, const QByteArray &imageData, int id,
+                              const QUrl &url, const QString &oldParent, const QString &newParent);
+    void changeFolderParent(const QString &name, bool isSubfolder);
+
 private:
     void dropEvent(QDropEvent* e);
     void dragEnterEvent(QDragEnterEvent* e);

--- a/src/lib/sidebar/bookmarkssidebar.h
+++ b/src/lib/sidebar/bookmarkssidebar.h
@@ -61,6 +61,10 @@ private slots:
     void removeFolder(const QString &name);
     void renameFolder(const QString &before, const QString &after);
 
+    void changeBookmarkParent(const QString &name, const QByteArray &imageData, int id,
+                              const QUrl &url, const QString &oldParent, const QString &newParent);
+    void changeFolderParent(const QString &name, bool isSubfolder);
+
 private:
     void keyPressEvent(QKeyEvent* event);
 

--- a/src/lib/tools/treewidget.h
+++ b/src/lib/tools/treewidget.h
@@ -43,9 +43,15 @@ public:
     void deleteItem(QTreeWidgetItem* item);
     void deleteItems(const QList<QTreeWidgetItem*> &items);
 
+    void setDragDropReceiver(bool enable, QObject* receiver = 0);
+
 signals:
     void itemControlClicked(QTreeWidgetItem* item);
     void itemMiddleButtonClicked(QTreeWidgetItem* item);
+
+    void linkWasDroped(const QUrl &url, const QString &title, const QVariant &imageVariant, const QString &folder, bool* ok);
+    void bookmarkParentChanged(int id, const QString &newParent, const QString &oldParent, bool* ok);
+    void folderParentChanged(const QString &name, bool isSubfolder, bool* ok);
 
 public slots:
     void filterString(QString string);
@@ -57,6 +63,13 @@ private slots:
 private:
     void mousePressEvent(QMouseEvent* event);
     void iterateAllItems(QTreeWidgetItem* parent);
+
+    Qt::DropActions supportedDropActions();
+    QStringList mimeTypes() const;
+    QMimeData *mimeData(const QList<QTreeWidgetItem *> items) const;
+    bool dropMimeData(QTreeWidgetItem *parent, int, const QMimeData *data, Qt::DropAction action);
+    void dragEnterEvent(QDragEnterEvent *event);
+    void dragMoveEvent(QDragMoveEvent* event);
 
     bool m_refreshAllItemsNeeded;
     QList<QTreeWidgetItem*> m_allTreeItems;


### PR DESCRIPTION
-I try to minimize database's queries to achieve a better response when dropping.
-The idea is re-parenting items when it's possible.
-Also you can directly drag-n-drop a link to `bookmarkmanager` or `bookmarksidebar`.

-There are no new translatable strings. :)
