### PR TITLE
    Rework the quick bookmark widget.

### DIFF
--- a/src/lib/bookmarks/bookmarkswidget.h
+++ b/src/lib/bookmarks/bookmarkswidget.h
@@ -50,7 +50,6 @@ private slots:
     void removeBookmark();
     void saveBookmark();
 
-    void addBookmark();
     void toggleSpeedDial();
 
 private:

--- a/src/lib/bookmarks/bookmarkswidget.ui
+++ b/src/lib/bookmarks/bookmarkswidget.ui
@@ -17,19 +17,6 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
-      <widget class="QPushButton" name="removeBookmark">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Remove</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -111,7 +98,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="save">
+      <widget class="QPushButton" name="saveRemove">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>


### PR DESCRIPTION
This commit does not change strings.
- QupZilla is not firefox or chrome: QZ has speeddial by default, the latter ones only by extensions.
  So adding an url to the unsorted bookmarks by default when clicking the star is a no-go, as the user probably only wants to add a speed dial.
  The star is the only possibility to add speed dials.
- Having a save and a remove-button possibly confuses the user (at least confused me ;))
  Only take one button and change the text according to the state.
- Disable the name-edit and folder-combo in the case the url is already bookmarked.
  Chosing another folder and press save will move the bookmark to another folder.
  Moving bookmarks IMHO is the job of the "organize bookmarks" tool (renaming them, too)

---

In a future (post-1.3.5) I would like to see the bookmark-button an the folder-choser merged like it is done in Opera. (Opera HAS speed dial by default)
But I am open for suggestions :)
