### PR TITLE
Render the bar darker, if set to "Top" or "Bottom", as the small bar cou...

### DIFF
--- a/src/lib/navigation/locationbar.cpp
+++ b/src/lib/navigation/locationbar.cpp
@@ -578,7 +578,7 @@ void LocationBar::onMessage(Qz::AppMessageType msg, bool state)
 
 void LocationBar::hideProgress()
 {
-    if (qzSettings->showLoadingProgress) {
+    if (qzSettings->showLoadingProgress && m_loadProgress == 100) {
         m_progressVisible = false;
         update();
     }
@@ -618,7 +618,7 @@ void LocationBar::paintEvent(QPaintEvent* event)
         if (!bg.isValid() || bg.alpha() == 0) {
             bg = Colors::mid(palette().color(QPalette::Base),
                              palette().color(QPalette::Text),
-                             10, 1);
+                             m_progressStyle > 0 ? 4 : 8, 1);
         }
         p.setBrush(QBrush(bg));
 


### PR DESCRIPTION
...ld be too hard to recognize.

Also set m_progressVisible only to false (in hideProgress), if m_loadProgress==100. If the user clicks
a link during the 700ms-timeout, the bar shows for a short time and hideProgress sets m_progressVisible to false, though
the page still is loading, which hides the bar in mid-run.
This also fixes the weird behaviour of the progressbar on session-restore.
