### PR TITLE
Build fails due to underlinking

### DIFF
--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -401,6 +401,8 @@ RESOURCES += \
     target.path = $$library_folder
 
     INSTALLS += target
+
+    LIBS += -lX11
 }
 
 message(===========================================)


### PR DESCRIPTION
Under certain configurations, QupZilla will fail to build due to underlinking:

```
cd src/main/ && make -f Makefile 
make[1]: Entering directory `/home/alec/code/qupzilla/src/main'
g++ -Wl,-O1 -o ../../bin/qupzilla ../../build/main.o    -L/usr/lib64/qt4 ../../bin/libQupZilla.so -lQtWebKit -lQtDBus -L/usr/lib64 -L/usr/lib64/qt4 -lQtXml -lQtScript -lQtSql -lQtGui -L/usr/X11R6/lib -lQtNetwork -lQtCore -lgthread-2.0 -lrt -lglib-2.0 -lpthread 
../../bin/libQupZilla.so: error: undefined reference to 'XInternAtom'
../../bin/libQupZilla.so: error: undefined reference to 'XGetWindowProperty'
../../bin/libQupZilla.so: error: undefined reference to 'XFree'
../../bin/libQupZilla.so: error: undefined reference to 'XChangeProperty'
collect2: ld returned 1 exit status
make[1]: *** [../../bin/qupzilla] Error 1
make[1]: Leaving directory `/home/alec/code/qupzilla/src/main'
make: *** [sub-src-main-make_default-ordered] Error 2
```

This is because it tries to access symbols from libX11 without directly linking to the library.

For more in-depth information, see here: http://blog.flameeyes.eu/2010/11/it-s-not-all-gold-that-shines-why-underlinking-is-a-bad-thing
