### PR TITLE
Hide supermenu in fullscreen mode.

### DIFF
--- a/src/lib/app/qupzilla.cpp
+++ b/src/lib/app/qupzilla.cpp
@@ -1510,6 +1510,10 @@ void QupZilla::fullScreen(bool make)
         bookmarksToolbar()->hide();
         m_navigationBar->hide();
         m_tabWidget->getTabBar()->hide();
+#ifndef Q_OS_MAC
+        m_navigationBar->buttonSuperMenu()->hide();
+#endif
+
 #ifdef Q_OS_WIN
         if (m_usingTransparentBackground) {
             QtWin::extendFrameIntoClientArea(this, 0, 0, 0 , 0);
@@ -1525,6 +1529,10 @@ void QupZilla::fullScreen(bool make)
         m_bookmarksToolbar->setVisible(m_bookmarksToolBarVisible);
         m_navigationBar->setVisible(m_navigationVisible);
         m_tabWidget->showTabBar();
+#ifndef Q_OS_MAC
+        m_navigationBar->buttonSuperMenu()->setVisible(!m_menuBarVisible);
+#endif
+
 #ifdef Q_OS_WIN
         if (m_usingTransparentBackground) {
             applyBlurToMainWindow(true);


### PR DESCRIPTION
Fixed this:
1- Hide menubar
2- Goto fullscreen
3- Un-hide menubar (Super-Menu is visible)
4- Exit from fullscreen 
5- No menubar and no supermenu!

<b>A note related to fullscreen:</b> On Mac F11 is shortcut for hide/un-hide Dashboard, QupZilla have to use another shortcut on this OS. (CMD+F11 or Shift+CMD+F and etc.)
