### PR TITLE
remove CloseButton::hideEvent()

### DIFF
--- a/src/lib/webview/tabbar.cpp
+++ b/src/lib/webview/tabbar.cpp
@@ -647,15 +647,6 @@ void CloseButton::leaveEvent(QEvent* event)
     QAbstractButton::leaveEvent(event);
 }
 
-void CloseButton::hideEvent(QHideEvent* event)
-{
-    QAbstractButton::hideEvent(event);
-
-    if (!isVisible()) {
-        deleteLater();
-    }
-}
-
 void CloseButton::paintEvent(QPaintEvent*)
 {
     QPainter p(this);

--- a/src/lib/webview/tabbar.h
+++ b/src/lib/webview/tabbar.h
@@ -128,7 +128,6 @@ public:
 
     void enterEvent(QEvent* event);
     void leaveEvent(QEvent* event);
-    void hideEvent(QHideEvent* event);
     void paintEvent(QPaintEvent* event);
 };
 


### PR DESCRIPTION
That causes crashes when entering/leaving fullscreen mode when the tabbar has non-closable tabs.
deleteLater() in the hideEvent left a dangling pointer in the corresponding QTabBarPrivate::Tab.
The next re-layout of the tabs caused the crash when querying the size of the deleted closeButton:

bt
https://gist.github.com/3947208

[...]
