### PR TITLE
Don't crash on adblock menu when adblock is disabled.

### DIFF
--- a/src/lib/adblock/adblockicon.cpp
+++ b/src/lib/adblock/adblockicon.cpp
@@ -111,7 +111,7 @@ void AdBlockIcon::createMenu(QMenu* menu)
     menu->addAction(tr("Show AdBlock &Settings"), manager, SLOT(showDialog()));
     menu->addSeparator();
 
-    if (!pageUrl.isEmpty()) {
+    if (!pageUrl.isEmpty() && m_enabled) {
         const QString &host = page->url().host().contains(QLatin1String("www.")) ? pageUrl.host().mid(4) : pageUrl.host();
         const QString &hostFilter = QString("@@||%1^$document").arg(host);
         const QString &pageFilter = QString("@@|%1|$document").arg(pageUrl.toString());


### PR DESCRIPTION
Whe adblock is disabled, the adblock-submenu from the contextmenu still queries custom filters on a NULL object. Only go in there when m_enabled is true.
(I was tempted to rename AdBlockIcon::setEnabled to something like setAbBlockEnabled, as setEnabled is inherited from QWidget)
