### PR TITLE
PIM plugin tune-ups

### DIFF
--- a/src/plugins/PIM/PIM_handler.cpp
+++ b/src/plugins/PIM/PIM_handler.cpp
@@ -114,6 +114,12 @@ void PIM_Handler::populateWebViewMenu(QMenu* menu, WebView* view, const QWebHitT
 
     QMenu* pimMenu = new QMenu(tr("Insert Personal Information"));
     pimMenu->setIcon(QIcon(":/PIM/data/PIM.png"));
+    
+    if (!m_allInfo[PI_FirstName].isEmpty() && !m_allInfo[PI_LastName].isEmpty()) {
+        const QString fullname = m_allInfo[PI_FirstName] + " " + m_allInfo[PI_LastName];
+        QAction* action = pimMenu->addAction(fullname, this, SLOT(pimInsert()));
+        action->setData(fullname);
+    }
 
     for (int i = 0; i < PI_Max; ++i) {
         const QString &info = m_allInfo[PI_Type(i)];


### PR DESCRIPTION
1. Instead of data titles in menu action arrays display actual data. Makes sense for a user to actually see what data he/she will be send into an input
2. Sometimes input on page requires full name. This commit adds full name into menu action array if both name and last name are defined
   ![aaaaaaa2](https://f.cloud.github.com/assets/913292/8204/fdcb1658-4468-11e2-8063-29b844d51fe2.png)
