### PR TITLE
Added hint for building on Fedora (qmake versions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Then you can start compiling by running this commands:
     $ make
 
 After a successful compilation the executable binary can be found in the bin/ directory.
+On Fedora and possibly other Linux distributions you need to replace `qmake` with `qmake-qt4` or `qmake-qt5` since `qmake` is for Qt3.
 
 On Linux/Unix: To install QupZilla, run this command: (it may be necessary to run it as root)
 


### PR DESCRIPTION
On Fedora you have:
qmake (Qt 3)
qmake-qt4 (Qt 4)
qmake-qt5 (Qt 5)
So using `qmake` does not work since qupzilla is designed for Qt4/Qt5.
