### PR TITLE
add reloadAll() to speed dial

### DIFF
--- a/src/lib/data/html/speeddial.html
+++ b/src/lib/data/html/speeddial.html
@@ -206,7 +206,7 @@ function allPages() {
 function reloadAll() {
     $('div.entry').each(function(i) {
         onReloadClick($(this));
-    }
+    });
 }
 
 function addBox(url, title, img_source) {


### PR DESCRIPTION
The reloadAll() function reloads all the speed dial bookmarks by calling onReloadClick() on each of them. 
TODO: add icon to make use of this function.
