### PR TITLE
[HistoryMenu] Improvements

### DIFF
--- a/src/lib/history/historymenu.cpp
+++ b/src/lib/history/historymenu.cpp
@@ -156,6 +156,17 @@ void HistoryMenu::aboutToShowClosedTabs()
         return;
     }
 
+    QAction* arestore = new QAction(tr("Restore All Closed Tabs"), this);
+    QAction* aclrlist = new QAction(tr("Clear list"), this);
+
+    connect(arestore, SIGNAL(triggered()), this, SLOT(restoreAllClosedTabs()));
+    connect(aclrlist, SIGNAL(triggered()), this, SLOT(clearClosedTabsList()));
+
+    m_menuClosedTabs->addAction(arestore);
+    m_menuClosedTabs->addAction(aclrlist);
+
+    m_menuClosedTabs->addSeparator();
+
     TabWidget* tabWidget = m_window->tabWidget();
     const QLinkedList<ClosedTabsManager::Tab> closedTabs = tabWidget->closedTabsManager()->allClosedTabs();
     int i = 0;
@@ -166,14 +177,10 @@ void HistoryMenu::aboutToShowClosedTabs()
         act->setData(i++);
     }
 
-    m_menuClosedTabs->addSeparator();
-
-    if (m_menuClosedTabs->isEmpty()) {
+    if (i == 0) {
+        arestore->setVisible(false);
+        aclrlist->setVisible(false);
         m_menuClosedTabs->addAction(tr("Empty"))->setEnabled(false);
-    }
-    else {
-        m_menuClosedTabs->addAction(tr("Restore All Closed Tabs"), tabWidget, SLOT(restoreAllClosedTabs()));
-        m_menuClosedTabs->addAction(tr("Clear list"), tabWidget, SLOT(clearClosedTabsList()));
     }
 }
 

--- a/src/lib/rss/rssmanager.cpp
+++ b/src/lib/rss/rssmanager.cpp
@@ -400,7 +400,7 @@ bool RSSManager::addRssFeed(const QUrl &url, const QString &title, const QIcon &
         QImage image = icon.pixmap(16, 16).toImage();
 
         if (image == qIconProvider->emptyWebImage()) {
-            image.load(":icons/other/feed.png");
+            image.load(":icons/menu/rss.png");
         }
 
         query.prepare("INSERT INTO rss (address, title, icon) VALUES(?,?,?)");

--- a/src/lib/webview/tabwidget.cpp
+++ b/src/lib/webview/tabwidget.cpp
@@ -820,7 +820,7 @@ void TabWidget::aboutToShowClosedTabsMenu()
         m_menuTabs->clear();
 
         QAction* arestore = new QAction(tr("Restore All Closed Tabs"), this);
-        QAction* aclrlist = new QAction(tr("Clear list"), this);
+        QAction* aclrlist = new QAction(QIcon::fromTheme("user-trash-full"), tr("Clear list"), this);
 
         connect(arestore, SIGNAL(triggered()), this, SLOT(restoreAllClosedTabs()));
         connect(aclrlist, SIGNAL(triggered()), this, SLOT(clearClosedTabsList()));
@@ -844,7 +844,7 @@ void TabWidget::aboutToShowClosedTabsMenu()
         if (i == 0) {
             arestore->setVisible(false);
             aclrlist->setVisible(false);
-            m_menuTabs->addAction(tr("Empty"))->setEnabled(false);
+            m_menuTabs->addAction(QIcon::fromTheme("user-trash"), tr("Empty"))->setEnabled(false);
         }
     }
 }


### PR DESCRIPTION
- As per 3eede1d8a2f033160471c3ee643172df5e4ca206 rework list of closed tabs
- Use smaller icons for rss items (cleanup after 3a3e7341a2e99cbbbc02572d2bbdf620392d8356)
- Use icons for closed tabs menu actions on the tabbar
