### PR TITLE
MouseGestures: configurable mouse gesture button

### DIFF
--- a/src/lib/webtab/tabbedwebview.h
+++ b/src/lib/webtab/tabbedwebview.h
@@ -23,6 +23,7 @@
 
 class QLabel;
 class QHostInfo;
+class QInputEvent;
 
 class BrowserWindow;
 class TabWidget;
@@ -75,6 +76,8 @@ private slots:
 private:
     void contextMenuEvent(QContextMenuEvent* event);
     void mouseMoveEvent(QMouseEvent* event);
+    void mouseReleaseEvent(QMouseEvent* event);
+    void _doContextMenu(const QPoint &pos, const QPoint &globalPos);
 
     BrowserWindow* m_window;
     WebTab* m_webTab;

--- a/src/plugins/MouseGestures/mousegestures.cpp
+++ b/src/plugins/MouseGestures/mousegestures.cpp
@@ -28,11 +28,20 @@
 
 #include <QMouseEvent>
 #include <QWebFrame>
+#include <QSettings>
 
-MouseGestures::MouseGestures(QObject* parent) :
+MouseGestures::MouseGestures(const QString &settingsPath, QObject* parent) :
     QObject(parent)
+    , m_filter(0)
+    , m_button(Qt::MiddleButton)
+    , m_settingsFile(settingsPath + "extensions.ini")
 {
-    m_filter = new QjtMouseGestureFilter(false, Qt::MiddleButton, 20);
+    loadSettings();
+    initFilter();
+}
+
+void MouseGestures::initFilter() {
+    m_filter = new QjtMouseGestureFilter(false, m_button, 20);
 
     QjtMouseGesture* upGesture = new QjtMouseGesture(DirectionList() << Up, m_filter);
     connect(upGesture, SIGNAL(gestured()), this, SLOT(upGestured()));
@@ -108,7 +117,7 @@ bool MouseGestures::mouseMove(QObject* obj, QMouseEvent* event)
 void MouseGestures::showSettings(QWidget* parent)
 {
     if (!m_settings) {
-        m_settings = new MouseGesturesSettingsDialog(parent);
+        m_settings = new MouseGesturesSettingsDialog(this, parent);
     }
 
     m_settings.data()->show();
@@ -221,6 +230,69 @@ void MouseGestures::upRightGestured()
     else {
         view->tabWidget()->nextTab();
     }
+}
+
+void MouseGestures::setGestureButton(Qt::MouseButton button)
+{
+    if (m_filter) {
+        m_filter->clearGestures(true);
+        delete m_filter;
+        m_filter = NULL;
+    }
+
+    m_button = button;
+    initFilter();
+}
+
+void MouseGestures::setGestureButtonByIndex(int index)
+{
+    switch (index) {
+	default:
+        case 0:
+	    m_button = Qt::MiddleButton;
+	    break;
+        case 1:
+	    m_button = Qt::RightButton;
+	    break;
+        case 2:
+	    m_button = Qt::LeftButton;
+	    break;
+    }
+
+    setGestureButton(m_button);
+}
+
+Qt::MouseButton MouseGestures::gestureButton() const
+{
+    return m_button;
+}
+
+int MouseGestures::buttonToIndex() const
+{
+    switch (m_button) {
+	default:
+	case Qt::MiddleButton: return 0;
+	case Qt::RightButton: return 1;
+	case Qt::LeftButton: return 2;
+    }
+}
+
+void MouseGestures::loadSettings()
+{
+    QSettings settings(m_settingsFile, QSettings::IniFormat);
+
+    settings.beginGroup("MouseGestures");
+    setGestureButtonByIndex(settings.value("Button", 0).toInt());
+    settings.endGroup();
+}
+
+void MouseGestures::saveSettings()
+{
+    QSettings settings(m_settingsFile, QSettings::IniFormat);
+
+    settings.beginGroup("MouseGestures");
+    settings.setValue("Button", buttonToIndex());
+    settings.endGroup();
 }
 
 MouseGestures::~MouseGestures()

--- a/src/plugins/MouseGestures/mousegestures.h
+++ b/src/plugins/MouseGestures/mousegestures.h
@@ -31,7 +31,7 @@ class MouseGestures : public QObject
 {
     Q_OBJECT
 public:
-    explicit MouseGestures(QObject* parent = 0);
+    explicit MouseGestures(const QString &settingsPath, QObject* parent = 0);
     ~MouseGestures();
 
     bool mousePress(QObject* obj, QMouseEvent* event);
@@ -40,6 +40,14 @@ public:
 
     void showSettings(QWidget* parent);
     void unloadPlugin();
+
+    Qt::MouseButton gestureButton() const;
+    int buttonToIndex() const;
+    void setGestureButton(Qt::MouseButton button);
+    void setGestureButtonByIndex(int index);
+
+    void loadSettings();
+    void saveSettings();
 
 private slots:
     void upGestured();
@@ -55,9 +63,13 @@ private slots:
     void upRightGestured();
 
 private:
+    void initFilter();
+
     QjtMouseGestureFilter* m_filter;
     QPointer<MouseGesturesSettingsDialog> m_settings;
     QPointer<WebView> m_view;
+    Qt::MouseButton m_button;
+    QString m_settingsFile;
 };
 
 #endif // MOUSEGESTURES_H

--- a/src/plugins/MouseGestures/mousegesturesplugin.cpp
+++ b/src/plugins/MouseGestures/mousegesturesplugin.cpp
@@ -46,9 +46,8 @@ PluginSpec MouseGesturesPlugin::pluginSpec()
 void MouseGesturesPlugin::init(InitState state, const QString &settingsPath)
 {
     Q_UNUSED(state)
-    Q_UNUSED(settingsPath)
 
-    m_gestures = new MouseGestures(this);
+    m_gestures = new MouseGestures(settingsPath, this);
 
     QZ_REGISTER_EVENT_HANDLER(PluginProxy::MousePressHandler);
     QZ_REGISTER_EVENT_HANDLER(PluginProxy::MouseReleaseHandler);

--- a/src/plugins/MouseGestures/mousegesturessettingsdialog.cpp
+++ b/src/plugins/MouseGestures/mousegesturessettingsdialog.cpp
@@ -18,12 +18,14 @@
 #include "mousegesturessettingsdialog.h"
 #include "ui_mousegesturessettingsdialog.h"
 #include "licenseviewer.h"
+#include "mousegestures.h"
 
 #include <QLabel>
 
-MouseGesturesSettingsDialog::MouseGesturesSettingsDialog(QWidget* parent)
+MouseGesturesSettingsDialog::MouseGesturesSettingsDialog(MouseGestures* gestures, QWidget* parent)
     : QDialog(parent)
     , ui(new Ui::MouseGesturesSettingsDialog)
+    , m_gestures(gestures)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     ui->setupUi(this);
@@ -35,8 +37,13 @@ MouseGesturesSettingsDialog::MouseGesturesSettingsDialog(QWidget* parent)
         ui->label_20->setPixmap(QPixmap(":/mousegestures/data/up-left.gif"));
     }
 
+    m_gestures->loadSettings();
+    ui->mouseButtonComboBox->setCurrentIndex(m_gestures->buttonToIndex());
+
     setAttribute(Qt::WA_DeleteOnClose);
 
+    connect(ui->buttonBox, SIGNAL(accepted()), this, SLOT(accepted()));
+    connect(ui->buttonBox, SIGNAL(rejected()), this, SLOT(close()));
     connect(ui->licenseButton, SIGNAL(clicked()), this, SLOT(showLicense()));
 }
 
@@ -51,4 +58,11 @@ void MouseGesturesSettingsDialog::showLicense()
     v->setLicenseFile(":mousegestures/data/copyright");
 
     v->show();
+}
+
+void MouseGesturesSettingsDialog::accepted()
+{
+    m_gestures->setGestureButtonByIndex(ui->mouseButtonComboBox->currentIndex());
+    m_gestures->saveSettings();
+    close();
 }

--- a/src/plugins/MouseGestures/mousegesturessettingsdialog.h
+++ b/src/plugins/MouseGestures/mousegesturessettingsdialog.h
@@ -26,19 +26,23 @@ namespace Ui
 class MouseGesturesSettingsDialog;
 }
 
+class MouseGestures;
+
 class MouseGesturesSettingsDialog : public QDialog
 {
     Q_OBJECT
 
 public:
-    explicit MouseGesturesSettingsDialog(QWidget* parent = 0);
+    explicit MouseGesturesSettingsDialog(MouseGestures* gestures, QWidget* parent = 0);
     ~MouseGesturesSettingsDialog();
 
 private slots:
     void showLicense();
+    void accepted();
 
 private:
     Ui::MouseGesturesSettingsDialog* ui;
+    MouseGestures* m_gestures;
 };
 
 #endif // MOUSEGESTURESSETTINGSDIALOG_H

--- a/src/plugins/MouseGestures/mousegesturessettingsdialog.ui
+++ b/src/plugins/MouseGestures/mousegesturessettingsdialog.ui
@@ -61,10 +61,7 @@
    <item>
     <widget class="QLabel" name="label_17">
      <property name="text">
-      <string>Press and hold the middle mouse button and move your mouse in the indicated directions.</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
+      <string>Press and hold the mouse button and move your mouse in the indicated directions.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -72,17 +69,47 @@
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QLabel" name="label_22">
+       <property name="text">
+        <string>Mouse button:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="mouseButtonComboBox">
+       <item>
+        <property name="text">
+         <string>Middle button (default)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Right button (Opera 12.x)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Left button (not recommended)</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
@@ -260,7 +287,7 @@
         <enum>Qt::Horizontal</enum>
        </property>
        <property name="standardButtons">
-        <set>QDialogButtonBox::Close</set>
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
UI changes:
- the Settings dialog offers a combo box to select one of 3
  mouse buttons
- change is permanently saved
- OK button is added

The motivation is allow right mouse button for gestures. This interferes
with the context menu and needed to do custom handling of this event.

Context menu newly pops on mouse right button release unless a gesture
was recognized. In that case the gesture consumes the event and no
context menu appears.

Closes #386
