### PR TITLE
[BrowserWindow] Enable single key shortcuts

### DIFF
--- a/src/lib/app/browserwindow.cpp
+++ b/src/lib/app/browserwindow.cpp
@@ -407,6 +407,7 @@ void BrowserWindow::loadSettings()
     settings.beginGroup("Shortcuts");
     m_useTabNumberShortcuts = settings.value("useTabNumberShortcuts", true).toBool();
     m_useSpeedDialNumberShortcuts = settings.value("useSpeedDialNumberShortcuts", true).toBool();
+    m_useSingleKeyShortcuts = settings.value("useSingleKeyShortcuts", false).toBool();
     settings.endGroup();
 
     m_adblockIcon->setEnabled(settings.value("AdBlock/enabled", true).toBool());
@@ -1330,6 +1331,12 @@ void BrowserWindow::keyPressEvent(QKeyEvent* event)
                 loadAddress(url);
                 return;
             }
+        }
+        if (event->modifiers() == Qt::NoModifier && m_useSingleKeyShortcuts) {
+            if (number == 1)
+                m_tabWidget->previousTab();
+            if (number == 2)
+                m_tabWidget->nextTab();
         }
     }
 

--- a/src/lib/app/browserwindow.h
+++ b/src/lib/app/browserwindow.h
@@ -207,6 +207,7 @@ private:
     // Shortcuts
     bool m_useTabNumberShortcuts;
     bool m_useSpeedDialNumberShortcuts;
+    bool m_useSingleKeyShortcuts;
 
     // Remember visibility of menubar and statusbar after entering Fullscreen
     bool m_menuBarVisible;

--- a/src/lib/preferences/preferences.cpp
+++ b/src/lib/preferences/preferences.cpp
@@ -380,6 +380,7 @@ Preferences::Preferences(BrowserWindow* window, QWidget* parent)
     settings.beginGroup("Shortcuts");
     ui->switchTabsAlt->setChecked(settings.value("useTabNumberShortcuts", true).toBool());
     ui->loadSpeedDialsCtrl->setChecked(settings.value("useSpeedDialNumberShortcuts", true).toBool());
+    ui->singleKeyShortcuts->setChecked(settings.value("useSingleKeyShortcuts", false).toBool());
     settings.endGroup();
 
     //NOTIFICATIONS
@@ -964,6 +965,7 @@ void Preferences::saveSettings()
     settings.beginGroup("Shortcuts");
     settings.setValue("useTabNumberShortcuts", ui->switchTabsAlt->isChecked());
     settings.setValue("useSpeedDialNumberShortcuts", ui->loadSpeedDialsCtrl->isChecked());
+    settings.setValue("useSingleKeyShortcuts", ui->singleKeyShortcuts->isChecked());
     settings.endGroup();
 
     //BROWSING

--- a/src/lib/preferences/preferences.ui
+++ b/src/lib/preferences/preferences.ui
@@ -1987,7 +1987,14 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="1">
+           <item row="4" column="0" colspan="2">
+            <widget class="QCheckBox" name="singleKeyShortcuts">
+             <property name="text">
+              <string>Use single key shortcuts (1 - prev tab, 2 - next tab)</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1">
             <spacer name="verticalSpacer_13">
              <property name="orientation">
               <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Translate single keys to shortcuts:

1 - previous tab
2 - next tab
(basic Opera compatibility)

There are more to choose from, but 1 and 2 are probably the most used.
Full list:
http://help.opera.com/Windows/9.50/en/keyboard.html#single-key

Configurable in preferences/Keyboard shortcuts, off by default.

Closes #1172

Note: I don't know how to add a help text/tooltip to the checkbox, 'single key shortcuts' would be very terse on what's implemented, so the current two are mentioned.
