### PR TITLE
Add application category for OS X

### DIFF
--- a/src/main/Info.plist
+++ b/src/main/Info.plist
@@ -44,6 +44,9 @@
     <string>QupZilla</string>
     <key>CFBundleDisplayName</key>
     <string>QupZilla</string>
+    
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.productivity</string>
 
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>


### PR DESCRIPTION
Because /Applications is typically not subfoldered (updaters don't like it when it is) OS X has had a separate view option View --> Arrange By --> Application Category which simplifies viewing apps. Unfortunately if LSApplicationCategoryType is missing from the app's info.plist, the app will be sorted into "Other" at the bottom. public.app-category.productivity is the category for web browsers.
