### PR TITLE
Fix compile error with vc++ 2013

### DIFF
--- a/src/lib/app/qzcommon.cpp
+++ b/src/lib/app/qzcommon.cpp
@@ -24,7 +24,7 @@ const int sessionVersionQt5 = 0x0003 | 0x050000;
 const int bookmarksVersion = 1;
 
 const char* APPNAME = "QupZilla";
-const char* VERSION = QUPZILLA_VERSION;
+QUPZILLA_EXPORT const char* VERSION = QUPZILLA_VERSION;
 const char* BUILDTIME =  __DATE__" "__TIME__;
 const char* AUTHOR = "David Rosca";
 const char* COPYRIGHT = "2010-2014";

--- a/src/lib/app/qzcommon.h
+++ b/src/lib/app/qzcommon.h
@@ -63,7 +63,7 @@ extern const int sessionVersionQt5;
 extern const int bookmarksVersion;
 
 extern const char* APPNAME;
-extern const char* VERSION;
+QUPZILLA_EXPORT extern const char* VERSION;
 extern const char* BUILDTIME;
 extern const char* AUTHOR;
 extern const char* COPYRIGHT;


### PR DESCRIPTION
Compile error when building plugins: Qz::VERSION is not exported
