### PR TITLE
Language strings fixes. Closes #1318 #1329 #1337

### DIFF
--- a/src/lib/app/browserwindow.cpp
+++ b/src/lib/app/browserwindow.cpp
@@ -1378,7 +1378,7 @@ void BrowserWindow::closeEvent(QCloseEvent* event)
 
     if (askOnClose && m_tabWidget->normalTabsCount() > 1) {
         CheckBoxDialog dialog(QDialogButtonBox::Yes | QDialogButtonBox::No, this);
-        dialog.setText(tr("There are still %1 open tabs and your session won't be stored. \nAre you sure to close this window?").arg(m_tabWidget->count()));
+        dialog.setText(tr("There are still %n open tab(s) and your session won't be stored. \nAre you sure to close this window?", "", m_tabWidget->count()));
         dialog.setCheckBoxText(tr("Don't ask again"));
         dialog.setWindowTitle(tr("There are still open tabs"));
         dialog.setIcon(IconProvider::standardIcon(QStyle::SP_MessageBoxWarning));

--- a/src/lib/webkit/webpage.cpp
+++ b/src/lib/webkit/webpage.cpp
@@ -547,8 +547,8 @@ bool WebPage::acceptNavigationRequest(QWebFrame* frame, const QNetworkRequest &r
         if (!view() || !view()->isVisible()) {
             return false;
         }
-        QString message = tr("To show this page, QupZilla must resend request which do it again \n"
-                             "(like searching on making an shopping, which has been already done.)");
+        QString message = tr("To display this page, QupZilla must resend the request \n"
+                             "(such as a search or order confirmation) that was performed earlier.");
         bool result = (QMessageBox::question(view(), tr("Confirm form resubmission"),
                                              message, QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::Yes);
         if (!result) {

--- a/src/plugins/StatusBarIcons/sbi_imagesicon.cpp
+++ b/src/plugins/StatusBarIcons/sbi_imagesicon.cpp
@@ -53,7 +53,7 @@ void SBI_ImagesIcon::showMenu(const QPoint &point)
     boldFont.setBold(true);
 
     QMenu menu;
-    menu.addAction(m_icon, tr("Current page settings"))->setFont(boldFont);
+    menu.addAction(m_icon, tr("Current Page Settings"))->setFont(boldFont);
 
     if (testCurrentPageWebAttribute(QWebSettings::AutoLoadImages)) {
         menu.addAction(tr("Disable loading images (temporarily)"), this, SLOT(toggleLoadingImages()));
@@ -63,7 +63,7 @@ void SBI_ImagesIcon::showMenu(const QPoint &point)
     }
 
     menu.addSeparator();
-    menu.addAction(m_icon, tr("Global settings"))->setFont(boldFont);
+    menu.addAction(m_icon, tr("Global Settings"))->setFont(boldFont);
 
     QAction* act = menu.addAction(tr("Automatically load images"));
     act->setCheckable(true);

--- a/src/plugins/StatusBarIcons/sbi_javascripticon.cpp
+++ b/src/plugins/StatusBarIcons/sbi_javascripticon.cpp
@@ -47,7 +47,7 @@ void SBI_JavaScriptIcon::showMenu(const QPoint &point)
     boldFont.setBold(true);
 
     QMenu menu;
-    menu.addAction(m_icon, tr("Current page settings"))->setFont(boldFont);
+    menu.addAction(m_icon, tr("Current Page Settings"))->setFont(boldFont);
 
     if (testCurrentPageWebAttribute(QWebSettings::JavascriptEnabled)) {
         menu.addAction(tr("Disable JavaScript (temporarily)"), this, SLOT(toggleJavaScript()));
@@ -62,7 +62,7 @@ void SBI_JavaScriptIcon::showMenu(const QPoint &point)
     }
 
     menu.addSeparator();
-    menu.addAction(m_icon, tr("Global settings"))->setFont(boldFont);
+    menu.addAction(m_icon, tr("Global Settings"))->setFont(boldFont);
     menu.addAction(tr("Manage JavaScript settings"), this, SLOT(openJavaScriptSettings()));
     menu.exec(point);
 }

--- a/src/plugins/StatusBarIcons/sbi_networkicon.cpp
+++ b/src/plugins/StatusBarIcons/sbi_networkicon.cpp
@@ -63,7 +63,7 @@ void SBI_NetworkIcon::showMenu(const QPoint &pos)
     boldFont.setBold(true);
 
     QMenu menu;
-    menu.addAction(QIcon::fromTheme("preferences-system-network", QIcon(":sbi/data/preferences-network.png")), tr("Proxy configuration"))->setFont(boldFont);
+    menu.addAction(QIcon::fromTheme("preferences-system-network", QIcon(":sbi/data/preferences-network.png")), tr("Proxy Configuration"))->setFont(boldFont);
 
     QMenu* proxyMenu = menu.addMenu(tr("Select proxy"));
 

--- a/src/plugins/StatusBarIcons/translations/empty.ts
+++ b/src/plugins/StatusBarIcons/translations/empty.ts
@@ -10,7 +10,7 @@
     </message>
     <message>
         <location filename="../sbi_imagesicon.cpp" line="56"/>
-        <source>Current page settings</source>
+        <source>Current Page Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -25,7 +25,7 @@
     </message>
     <message>
         <location filename="../sbi_imagesicon.cpp" line="66"/>
-        <source>Global settings</source>
+        <source>Global Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -43,7 +43,7 @@
     </message>
     <message>
         <location filename="../sbi_javascripticon.cpp" line="50"/>
-        <source>Current page settings</source>
+        <source>Current Page Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -58,7 +58,7 @@
     </message>
     <message>
         <location filename="../sbi_javascripticon.cpp" line="65"/>
-        <source>Global settings</source>
+        <source>Global Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -71,7 +71,7 @@
     <name>SBI_NetworkIcon</name>
     <message>
         <location filename="../sbi_networkicon.cpp" line="66"/>
-        <source>Proxy configuration</source>
+        <source>Proxy Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/empty.ts
+++ b/translations/empty.ts
@@ -1142,11 +1142,14 @@ Please install latest version of QupZilla.</source>
         <source>QupZilla %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/lib/app/browserwindow.cpp" line="1378"/>
-        <source>There are still %1 open tabs and your session won&apos;t be stored. 
+        <source>There are still %n open tab(s) and your session won&apos;t be stored. 
 Are you sure to close this window?</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/lib/app/browserwindow.cpp" line="1379"/>
@@ -6127,8 +6130,8 @@ After adding or removing certificate paths, it is neccessary to restart QupZilla
     </message>
     <message>
         <location filename="../src/lib/webkit/webpage.cpp" line="550"/>
-        <source>To show this page, QupZilla must resend request which do it again 
-(like searching on making an shopping, which has been already done.)</source>
+        <source>To display this page, QupZilla must resend the request 
+(such as a search or order confirmation) that was performed earlier.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
The commit does the following:
- 1318: Capitalized words of the first level menu entries. IMHO there's no need to capitalize everything.
- 1329: Plural form for the string.

Issue 1337 is reported with three different problems:
- First one is actually not a problem, so it is ignored.
- The second one is what this commit "fixes" - it makes the string more understandable, inspired by the Firefox's string for data resending.
- The third problem is not reproducible by my setup, so I propose the user open another issue with more details, so we could focus more on the problem.
