### PR TITLE
[WebView] Fix bug with right-click on selected link

### DIFF
--- a/src/lib/webkit/webview.cpp
+++ b/src/lib/webkit/webview.cpp
@@ -1073,9 +1073,11 @@ void WebView::createPageContextMenu(QMenu* menu, const QPoint &pos)
 void WebView::createLinkContextMenu(QMenu* menu, const QWebHitTestResult &hitTest)
 {
     // Workaround for QtWebKit <= 2.0 when selecting link text on right click
+#if QTWEBKIT_TO_2_2
     if (page()->selectedText() == hitTest.linkText()) {
         findText(QString());
     }
+#endif
 
     menu->addSeparator();
     Action* act = new Action(IconProvider::newTabIcon(), tr("Open link in new &tab"));


### PR DESCRIPTION
This has been bothered me for a long time. Every time I right-click on a selected one-word link, only the link context menu would appear. Workaround was to select non-linked word or character (such as blank space) together with the linked word, but it would mean that unwanted characters are copied. With this fix, right-click on a selected one-word link displays correctly both link and text context menu.
