### PR TITLE
Don't refresh whole bookmarks-menu on change,

### DIFF
--- a/src/lib/bookmarks/bookmarkitem.cpp
+++ b/src/lib/bookmarks/bookmarkitem.cpp
@@ -24,6 +24,7 @@ BookmarkItem::BookmarkItem(BookmarkItem::Type type, BookmarkItem* parent)
     , m_visitCount(0)
     , m_expanded(false)
     , m_sidebarExpanded(false)
+    , m_changed(true)
 {
     if (m_parent) {
         parent->addChild(this);
@@ -189,6 +190,16 @@ void BookmarkItem::removeChild(BookmarkItem* child)
 {
     child->m_parent = 0;
     m_children.removeOne(child);
+}
+
+bool BookmarkItem::isChanged() const
+{
+    return m_changed;
+}
+
+void BookmarkItem::setChanged(bool changed)
+{
+    m_changed = changed;
 }
 
 BookmarkItem::Type BookmarkItem::typeFromString(const QString &string)

--- a/src/lib/bookmarks/bookmarkitem.h
+++ b/src/lib/bookmarks/bookmarkitem.h
@@ -82,6 +82,12 @@ public:
     void addChild(BookmarkItem* child, int index = -1);
     void removeChild(BookmarkItem* child);
 
+    // Only applicable to Folder type,
+    // return true if at least one of item's children
+    // has changed/removed or a new child has added
+    bool isChanged() const;
+    void setChanged(bool changed);
+
     static Type typeFromString(const QString &string);
     static QString typeToString(Type type);
 
@@ -99,6 +105,7 @@ private:
     int m_visitCount;
     bool m_expanded;
     bool m_sidebarExpanded;
+    bool m_changed;
 };
 
 #endif // BOOKMARKITEM_H

--- a/src/lib/bookmarks/bookmarks.cpp
+++ b/src/lib/bookmarks/bookmarks.cpp
@@ -142,6 +142,8 @@ void Bookmarks::insertBookmark(BookmarkItem* parent, int row, BookmarkItem* item
 
     m_lastFolder = parent;
     m_model->addBookmark(parent, row, item);
+    parent->setChanged(true);
+
     emit bookmarkAdded(item);
 
     m_autoSaver->changeOcurred();
@@ -151,6 +153,10 @@ bool Bookmarks::removeBookmark(BookmarkItem* item)
 {
     if (!canBeModified(item)) {
         return false;
+    }
+
+    if (item && item->parent()) {
+        item->parent()->setChanged(true);
     }
 
     m_model->removeBookmark(item);
@@ -163,6 +169,11 @@ bool Bookmarks::removeBookmark(BookmarkItem* item)
 void Bookmarks::changeBookmark(BookmarkItem* item)
 {
     Q_ASSERT(item);
+
+    if (item && item->parent()) {
+        item->parent()->setChanged(true);
+    }
+
     emit bookmarkChanged(item);
 
     m_autoSaver->changeOcurred();

--- a/src/lib/bookmarks/bookmarkstools.cpp
+++ b/src/lib/bookmarks/bookmarkstools.cpp
@@ -33,6 +33,8 @@
 #include <QLineEdit>
 #include <QStyle>
 #include <QDialog>
+#include <QApplication>
+#include <QDesktopWidget>
 
 // BookmarksFoldersMenu
 BookmarksFoldersMenu::BookmarksFoldersMenu(QWidget* parent)
@@ -310,21 +312,19 @@ void BookmarksTools::addFolderToMenu(QObject* receiver, Menu* menu, BookmarkItem
     Q_ASSERT(folder);
     Q_ASSERT(folder->isFolder());
 
-    Menu* m = new Menu(folder->title());
+    Menu* m = new Menu;
+    static int width = qMin(500, QApplication::desktop()->screenGeometry(menu).width() / 4);
+    QString title = QFontMetrics(m->font()).elidedText(folder->title(), Qt::ElideRight, width);
+
+    m->setTitle(title);
     m->setIcon(folder->icon());
+
     QObject::connect(m, SIGNAL(menuMiddleClicked(Menu*)), receiver, SLOT(menuMiddleClicked(Menu*)));
+    QObject::connect(m, SIGNAL(aboutToShow()), receiver, SLOT(aboutToShow()));
 
     QAction* act = menu->addMenu(m);
     act->setData(QVariant::fromValue<void*>(static_cast<void*>(folder)));
     act->setIconVisibleInMenu(true);
-
-    foreach (BookmarkItem* child, folder->children()) {
-        addActionToMenu(receiver, m, child);
-    }
-
-    if (m->isEmpty()) {
-        m->addAction(Bookmarks::tr("Empty"))->setDisabled(true);
-    }
 }
 
 void BookmarksTools::addUrlToMenu(QObject* receiver, Menu* menu, BookmarkItem* bookmark)
@@ -333,7 +333,14 @@ void BookmarksTools::addUrlToMenu(QObject* receiver, Menu* menu, BookmarkItem* b
     Q_ASSERT(bookmark);
     Q_ASSERT(bookmark->isUrl());
 
-    Action* act = new Action(bookmark->icon(), bookmark->title());
+    Action* act = new Action;
+
+    static int width = qMin(500, QApplication::desktop()->screenGeometry(menu).width() / 4);
+    QString title = QFontMetrics(act->font()).elidedText(bookmark->title(), Qt::ElideRight, width);
+
+    act->setText(title);
+    act->setIcon(bookmark->icon());
+
     act->setData(QVariant::fromValue<void*>(static_cast<void*>(bookmark)));
     act->setIconVisibleInMenu(true);
 


### PR DESCRIPTION
And, limit width of action's title.

Is `qMin(500, QApplication::desktop()->screenGeometry(menu).width() / 4)` a good limit?
