### PR TITLE
[Preferences] add option to set Ctrl-Q behaviour (Quit or nothing)

### DIFF
--- a/src/lib/app/browserwindow.cpp
+++ b/src/lib/app/browserwindow.cpp
@@ -98,6 +98,17 @@
 
 const QString BrowserWindow::WEBKITVERSION = qWebKitVersion();
 
+static QKeySequence actionShortcut(QKeySequence shortcut, QKeySequence fallBack, QKeySequence shortcutRTL = QKeySequence(), QKeySequence fallbackRTL = QKeySequence())
+{
+    if (QApplication::isRightToLeft() && (!shortcutRTL.isEmpty() || !fallbackRTL.isEmpty())) {
+        return (shortcutRTL.isEmpty() ? fallbackRTL : shortcutRTL);
+    }
+    else {
+        return (shortcut.isEmpty() ? fallBack : shortcut);
+    }
+}
+
+
 BrowserWindow::BrowserWindow(Qz::BrowserWindowType type, const QUrl &startUrl)
     : QMainWindow(0)
     , m_startUrl(startUrl)
@@ -411,6 +422,15 @@ void BrowserWindow::loadSettings()
     m_useTabNumberShortcuts = settings.value("useTabNumberShortcuts", true).toBool();
     m_useSpeedDialNumberShortcuts = settings.value("useSpeedDialNumberShortcuts", true).toBool();
     m_useSingleKeyShortcuts = settings.value("useSingleKeyShortcuts", false).toBool();
+    settings.endGroup();
+
+    settings.beginGroup("Web-Browser-Settings");
+    QAction *quitAction = m_mainMenu->action(QSL("Standard/Quit"));
+    if (settings.value("closeAppWithCtrlQ", true).toBool()) {
+        quitAction->setShortcut(actionShortcut(QKeySequence::Quit, QKeySequence(QSL("Ctrl+Q"))));
+    } else {
+        quitAction->setShortcut(QKeySequence());
+    }
     settings.endGroup();
 
     m_adblockIcon->setEnabled(settings.value("AdBlock/enabled", true).toBool());

--- a/src/lib/app/mainmenu.cpp
+++ b/src/lib/app/mainmenu.cpp
@@ -39,16 +39,6 @@
 #include <QWebPage>
 #include <QMenuBar>
 
-static QKeySequence actionShortcut(QKeySequence shortcut, QKeySequence fallBack, QKeySequence shortcutRTL = QKeySequence(), QKeySequence fallbackRTL = QKeySequence())
-{
-    if (QApplication::isRightToLeft() && (!shortcutRTL.isEmpty() || !fallbackRTL.isEmpty())) {
-        return (shortcutRTL.isEmpty() ? fallbackRTL : shortcutRTL);
-    }
-    else {
-        return (shortcut.isEmpty() ? fallBack : shortcut);
-    }
-}
-
 MainMenu::MainMenu(BrowserWindow* window, QWidget* parent)
     : QMenu(parent)
     , m_window(window)
@@ -516,7 +506,7 @@ void MainMenu::init()
 
     action = new QAction(QIcon::fromTheme(QSL("application-exit")), tr("Quit"), this);
     action->setMenuRole(QAction::QuitRole);
-    action->setShortcut(actionShortcut(QKeySequence::Quit, QKeySequence(QSL("Ctrl+Q"))));
+    // shortcut set from browserwindow
     connect(action, SIGNAL(triggered()), this, SLOT(quitApplication()));
     m_actions[QSL("Standard/Quit")] = action;
 

--- a/src/lib/preferences/preferences.cpp
+++ b/src/lib/preferences/preferences.cpp
@@ -295,6 +295,7 @@ Preferences::Preferences(BrowserWindow* window, QWidget* parent)
         ui->defaultZoomLevel->addItem(QString("%1%").arg(level));
     }
     ui->defaultZoomLevel->setCurrentIndex(settings.value("DefaultZoomLevel", WebView::zoomLevels().indexOf(100)).toInt());
+    ui->closeAppWithCtrlQ->setChecked(settings.value("closeAppWithCtrlQ", true).toBool());
 
     //Cache
     ui->pagesInCache->setValue(settings.value("maximumCachedPages", 3).toInt());
@@ -995,6 +996,7 @@ void Preferences::saveSettings()
     settings.setValue("DefaultZoomLevel", ui->defaultZoomLevel->currentIndex());
     settings.setValue("XSSAuditing", ui->xssAuditing->isChecked());
     settings.setValue("enableFormsUndoRedo", ui->formsUndoRedo->isChecked());
+    settings.setValue("closeAppWithCtrlQ", ui->closeAppWithCtrlQ->isChecked());
 #ifdef Q_OS_WIN
     settings.setValue("CheckDefaultBrowser", ui->checkDefaultBrowser->isChecked());
 #endif

--- a/src/lib/preferences/preferences.ui
+++ b/src/lib/preferences/preferences.ui
@@ -1997,7 +1997,17 @@
              </property>
             </widget>
            </item>
-           <item row="5" column="1">
+           <item row="5" column="0" colspan="2">
+            <widget class="QCheckBox" name="closeAppWithCtrlQ">
+             <property name="toolTip">
+              <string>If unchecked, prevents accidental exit from the application if the Ctrl-W shortcut was intended.</string>
+             </property>
+             <property name="text">
+              <string>Close application with Ctrl-Q</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="1">
             <spacer name="verticalSpacer_13">
              <property name="orientation">
               <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Motivated by #695 which targets broader task, Ctrl-Q behaviour is one
that stands out. Accidentally pressing it instead of Ctrl-W can have
disasterous consequences or is annoying. Other browsers provide either
generic keyboard shortcuts configuration (Opera) or an extension/plugin
to disable the behaviour (FF).

For the record of the usability demand:
https://code.google.com/p/chromium/issues/detail?id=59621
https://bugzilla.mozilla.org/show_bug.cgi?id=550559
