### PR TITLE
Refactor encoding menu creation

### DIFF
--- a/src/lib/app/browserwindow.h
+++ b/src/lib/app/browserwindow.h
@@ -175,6 +175,10 @@ private:
     void setupUi();
     void setupMenu();
 
+    QAction *createEncodingAction(const QString &codecName, const QString &activeCodecName,
+                                  QMenu *menu);
+    void createEncodingSubMenu(const QString &name, QStringList &codecNames, QMenu *menu);
+
     QUrl m_startUrl;
     QUrl m_homepage;
     Qz::BrowserWindowType m_windowType;


### PR DESCRIPTION
This is an interim solution to the duplicated entries in the encoding menu and memory leaks.

Changes:
- Use of codec MIBs instead of names significantly decreases number of iterations.
- Remove duplicated codecs.
- Fix memory leaks which were caused by wrong parenting and empty menus.
- Do not add separator if menu is empty.

TODO:
- menus should be hard coded and organised by language groups (like Firefox) instead of charset groups or at least sorted alphanumerically
- createEncodingMenu should be called only once, instead of each time user accesses it
