### PR TITLE
Remove childFrames code in favor of simpler method

### DIFF
--- a/src/lib/autofill/pageformcompleter.cpp
+++ b/src/lib/autofill/pageformcompleter.cpp
@@ -236,16 +236,7 @@ QWebElementCollection PageFormCompleter::getAllElementsFromPage(const QString &s
     if (!m_page || !m_page->mainFrame())
         return list;
 
-    QList<QWebFrame*> frames;
-    frames.append(m_page->mainFrame());
-
-    while (!frames.isEmpty()) {
-        QWebFrame* frame = frames.takeFirst();
-        if (frame && !frame->documentElement().isNull()) {
-            list.append(frame->findAllElements(selector));
-            frames += frame->childFrames();
-        }
-    }
-
+    list = m_page->mainFrame()->findAllElements(selector);
+    
     return list;
 }


### PR DESCRIPTION
Autofill seems to work just as well and I haven't encountered any further childFrames crashes when built with Qt 4.  

Addresses #1417 
