### PR TITLE
fix linking on qmake installations that use compile_libtool.

### DIFF
--- a/src/main/main.pro
+++ b/src/main/main.pro
@@ -11,8 +11,13 @@ mac: TARGET = QupZilla
 
 TEMPLATE = app
 
+compile_libtool {
+LIBS += $$QZ_DESTDIR/libQupZilla.la
+}
+else {
 !unix|mac: LIBS += -L$$QZ_DESTDIR -lQupZilla
 !mac:unix: LIBS += $$QZ_DESTDIR/libQupZilla.so
+}
 
 unix:!contains(DEFINES, "DISABLE_DBUS") QT += dbus
 


### PR DESCRIPTION
On some qt installations (pkgsrc) qmake enables compile_libtool by default. Building qupzilla using compile_libtool breaks. This patch fixes this.
