### PR TITLE
Fix platform check

### DIFF
--- a/src/lib/3rdparty/processinfo.h
+++ b/src/lib/3rdparty/processinfo.h
@@ -18,6 +18,8 @@
 #ifndef PROCESSINFO_H
 #define PROCESSINFO_H
 
+#include <QtGlobal>
+
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
 #include <sys/types.h>
 #endif


### PR DESCRIPTION
Include <QtGlobal> which defines Q_OS_\* before the check, otherwise it may (and does on FreeBSD) work incorrectly
