### PR TITLE
Add 'Block domain' button to the cookie manager

### DIFF
--- a/src/lib/cookies/cookiemanager.h
+++ b/src/lib/cookies/cookiemanager.h
@@ -45,6 +45,7 @@ private slots:
     void currentItemChanged(QTreeWidgetItem* current, QTreeWidgetItem* parent);
     void removeCookie();
     void removeAll();
+    void blockCurrentHostAndRemoveCookie();
 
     void slotRefreshTable();
     void slotRefreshFilters();
@@ -62,6 +63,7 @@ private slots:
 private:
     void closeEvent(QCloseEvent* e);
     void keyPressEvent(QKeyEvent* e);
+    void addBlacklist(const QString &server);
 
     Ui::CookieManager* ui;
 

--- a/src/lib/cookies/cookiemanager.ui
+++ b/src/lib/cookies/cookiemanager.ui
@@ -226,6 +226,13 @@
            </widget>
           </item>
           <item>
+           <widget class="QPushButton" name="blockDomain">
+            <property name="text">
+             <string>Remove and block domain</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QDialogButtonBox" name="close">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">


### PR DESCRIPTION
So it is much simpler to remove a cookie, and get rid of a particularly offending cookie dropper site 