### PR TITLE
Use https for updating CA Certificates, prevent useless build of updater

### DIFF
--- a/src/lib/app/qzcommon.cpp
+++ b/src/lib/app/qzcommon.cpp
@@ -30,4 +30,5 @@ QUPZILLA_EXPORT const char* AUTHOR = "David Rosca";
 QUPZILLA_EXPORT const char* COPYRIGHT = "2010-2014";
 QUPZILLA_EXPORT const char* WWWADDRESS = "http://www.qupzilla.com";
 QUPZILLA_EXPORT const char* WIKIADDRESS = "https://github.com/QupZilla/qupzilla/wiki";
+QUPZILLA_EXPORT const char* RAWVCS = "https://raw.githubusercontent.com/QupZilla/qupzilla/v1.8";
 }

--- a/src/lib/app/qzcommon.h
+++ b/src/lib/app/qzcommon.h
@@ -69,6 +69,7 @@ QUPZILLA_EXPORT extern const char* AUTHOR;
 QUPZILLA_EXPORT extern const char* COPYRIGHT;
 QUPZILLA_EXPORT extern const char* WWWADDRESS;
 QUPZILLA_EXPORT extern const char* WIKIADDRESS;
+QUPZILLA_EXPORT extern const char* RAWVCS;
 
 enum BrowserWindowType {
     BW_FirstAppWindow,

--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -525,6 +525,8 @@ isEqual(QT_MAJOR_VERSION, 5) {
     !contains(DEFINES, NO_X11):LIBS += -lX11
     LIBS += -lcrypto
 
+    SOURCES -= network/cabundleupdater.cpp
+    HEADERS -= network/cabundleupdater.h
     RESOURCES -= data/certs.qrc
 }
 

--- a/src/lib/network/cabundleupdater.cpp
+++ b/src/lib/network/cabundleupdater.cpp
@@ -74,7 +74,7 @@ void CaBundleUpdater::start()
     if (updateNow) {
         m_progress = CheckLastUpdate;
 
-        QUrl url = QUrl::fromEncoded(QString(Qz::WWWADDRESS + QL1S("/certs/bundle_version")).toUtf8());
+        QUrl url = QUrl::fromEncoded(QString(Qz::RAWVCS + QL1S("/src/lib/data/data/bundle_version")).toUtf8());
         m_reply = m_manager->get(QNetworkRequest(url));
         connect(m_reply, SIGNAL(finished()), this, SLOT(replyFinished()));
     }
@@ -111,7 +111,7 @@ void CaBundleUpdater::replyFinished()
         if (m_latestBundleVersion > currentBundleVersion) {
             m_progress = LoadBundle;
 
-            QUrl url = QUrl::fromEncoded(QString(Qz::WWWADDRESS + QL1S("/certs/ca-bundle.crt")).toUtf8());
+            QUrl url = QUrl::fromEncoded(QString(Qz::RAWVCS + QL1S("/src/lib/data/data/ca-bundle.crt")).toUtf8());
             m_reply = m_manager->get(QNetworkRequest(url));
             connect(m_reply, SIGNAL(finished()), this, SLOT(replyFinished()));
         }


### PR DESCRIPTION
Both commits are tested only in Linux, so it means i did not check if updating actually works.

P.S.  About ```Will probably work only for Debian based distros``` comment from ```scripts/make_ca_bundle.sh```

```/etc/ssl/certs/ca-certificates.crt``` exists in Gentoo too:
```
$ du -sh /etc/ssl/certs/ca-certificates.crt src/lib/data/data/ca-bundle.crt
270K    /etc/ssl/certs/ca-certificates.crt
264K    src/lib/data/data/ca-bundle.crt
```

It is created by ```/usr/sbin/update-ca-certificates``` tool from ```app-misc/ca-certificates``` ebuild:
https://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/app-misc/ca-certificates/ca-certificates-20141019.3.17.4.ebuild?view=markup&revision=1.1