### PR TITLE
Fix not closing cmdline files from /proc/ on read errors

### DIFF
--- a/src/lib/3rdparty/processinfo.cpp
+++ b/src/lib/3rdparty/processinfo.cpp
@@ -85,11 +85,11 @@ pid_t ProcessInfo::GetPIDbyName(const char* cchrptr_ProcessName) const
                 if (fd_CmdLineFile) {
                     int r = fscanf(fd_CmdLineFile, "%20s", chrarry_NameOfProcess) ; // read from /proc/<NR>/cmdline
 
+                    fclose(fd_CmdLineFile);  // close the file prior to exiting the routine
+
                     if (r < 1) {
                         continue;
                     }
-
-                    fclose(fd_CmdLineFile);  // close the file prior to exiting the routine
 
                     if (strrchr(chrarry_NameOfProcess, '/')) {
                         chrptr_StringToCompare = strrchr(chrarry_NameOfProcess, '/') + 1 ;


### PR DESCRIPTION
The cmdline files opened from /proc/ were not closed if reading the data from them failed (e.g. because the file was empty). This leaked the file descriptor which could lead to failures trying to open more files later.

This fault also exists on the master branch (but the functionality is currently not used there).

Thanks!
