### PR TITLE
Fix breaking RSS feed database by editing URLs

### DIFF
--- a/src/lib/rss/rssmanager.cpp
+++ b/src/lib/rss/rssmanager.cpp
@@ -229,7 +229,7 @@ void RSSManager::editFeed()
 
     QSqlQuery query;
     query.prepare("UPDATE rss SET address=?, title=? WHERE address=?");
-    query.bindValue(0, address);
+    query.bindValue(0, QUrl(address));
     query.bindValue(1, title);
     query.bindValue(2, url);
     query.exec();


### PR DESCRIPTION
If the URL of an already added feed was edited to contain certain errors (e.g. a single "%") the feed could not be changed or deleted afterwards.
The fault was that edited URLs were stored in the database without being converted to a QUrl first. This conversion silently corrects some errors in the URL which also changes its value. The URLs read from the database are converted to QUrl before being set on the tabs and later are used to find entries to update or delete. This failed for edited URLs because of the now different values.
This was fixed by converting URLs from QString to QUrl before storing them in the database. Being already converted the value is then not changed if being converted again after reading and can be used for finding the entries to update or delete in the database.
