### PR TITLE
Fix not escaping characters for HTML directory listings (v1.8)

### DIFF
--- a/src/lib/network/schemehandlers/fileschemehandler.cpp
+++ b/src/lib/network/schemehandlers/fileschemehandler.cpp
@@ -170,7 +170,7 @@ QString FileSchemeReply::loadDirectory()
     QString page = sPage;
     QString title = request().url().toLocalFile();
     title.replace(QLatin1Char('/'), QDir::separator());
-    page.replace(QLatin1String("%TITLE%"), tr("Index for %1").arg(title));
+    page.replace(QLatin1String("%TITLE%"), tr("Index for %1").arg(QzTools::escape(title)));
     page.replace(QLatin1String("%CLICKABLE-TITLE%"), tr("Index for %1").arg(clickableSections(title)));
 
     QString upDirDisplay = QLatin1String("none");
@@ -203,7 +203,7 @@ QString FileSchemeReply::loadDirectory()
         line += QLatin1String("<a href=\"");
         line += QUrl::fromLocalFile(info.absoluteFilePath()).toEncoded();
         line += QLatin1String("\">");
-        line += info.fileName();
+        line += QzTools::escape(info.fileName());
         line += QLatin1String("</a></td><td class=\"td-size\">");
         line += info.isDir() ? QString() : QzTools::fileSizeToString(info.size());
         line += QLatin1String("</td><td>");
@@ -245,7 +245,7 @@ QString FileSchemeReply::clickableSections(const QString &path)
 #ifndef Q_OS_WIN
         localFile.prepend(dirSeparator);
 #endif
-        title += QString("<a href=\"%1\">%2</a>%3").arg(QUrl::fromLocalFile(localFile).toEncoded(), sections.at(i), dirSeparator);
+        title += QString("<a href=\"%1\">%2</a>%3").arg(QUrl::fromLocalFile(localFile).toEncoded(), QzTools::escape(sections.at(i)), dirSeparator);
     }
 
     return title;

--- a/src/lib/network/schemehandlers/ftpschemehandler.cpp
+++ b/src/lib/network/schemehandlers/ftpschemehandler.cpp
@@ -301,7 +301,7 @@ QString FtpSchemeReply::loadDirectory()
     else {
         title = QString::fromLatin1(titleByteArray);
     }
-    page.replace(QLatin1String("%TITLE%"), tr("Index for %1").arg(title));
+    page.replace(QLatin1String("%TITLE%"), tr("Index for %1").arg(QzTools::escape(title)));
     page.replace(QLatin1String("%CLICKABLE-TITLE%"), tr("Index for %1").arg(clickableSections(title)));
 
     QString upDirDisplay = QLatin1String("none");
@@ -352,7 +352,7 @@ QString FtpSchemeReply::loadDirectory()
         line += QLatin1String("<a href=\"");
         line += itemUrl.toEncoded();
         line += QLatin1String("\">");
-        line += item.name();
+        line += QzTools::escape(item.name());
         line += QLatin1String("</a></td><td class=\"td-size\">");
         line += item.isDir() ? QString() : QzTools::fileSizeToString(item.size());
         line += QLatin1String("</td><td>");
@@ -389,7 +389,7 @@ QString FtpSchemeReply::clickableSections(const QString &path)
     for (int i = 0; i < sections.size(); ++i) {
         QStringList currentParentSections = sections.mid(0, i + 1);
         QUrl currentParentUrl = QUrl(currentParentSections.join(QLatin1String("/")));
-        title += QString("<a href=\"%1\">%2</a>/").arg(currentParentUrl.toEncoded(), sections.at(i));
+        title += QString("<a href=\"%1\">%2</a>/").arg(currentParentUrl.toEncoded(), QzTools::escape(sections.at(i)));
     }
 
     return title;


### PR DESCRIPTION
The HTML pages created for FTP and file directory listings included the paths without escaping the HTML meta characters. The HTML generated for a path containing such characters was therefore not valid. This created problems when displaying or processing the page.

This should have been a rare problem because most paths do not contain such characters and the final display of the page (also the output from "Page Source") had most problems implicitly corrected (but not "<" followed by a letter).

Thanks!
