### PR TITLE
TabManager: Add an option to use it as main tabbar replacement.

### DIFF
--- a/src/lib/tabwidget/tabbar.cpp
+++ b/src/lib/tabwidget/tabbar.cpp
@@ -51,6 +51,7 @@ TabBar::TabBar(BrowserWindow* window, TabWidget* tabWidget)
     , m_clickedTab(0)
     , m_normalTabWidth(0)
     , m_activeTabWidth(0)
+    , m_forceHidden(false)
 {
     setObjectName("tabbar");
     setElideMode(Qt::ElideRight);
@@ -114,7 +115,9 @@ TabWidget* TabBar::tabWidget() const
 
 void TabBar::setVisible(bool visible)
 {
-    if (visible && m_window->isFullScreen()) {
+    if (m_forceHidden) {
+        hideTabPreview(false);
+        ComboTabBar::setVisible(false);
         return;
     }
 
@@ -125,6 +128,12 @@ void TabBar::setVisible(bool visible)
 
     hideTabPreview(false);
     ComboTabBar::setVisible(visible);
+}
+
+void TabBar::setForceHidden(bool hidden)
+{
+    m_forceHidden = hidden;
+    setVisible(!m_forceHidden);
 }
 
 void TabBar::overflowChanged(bool overflowed)

--- a/src/lib/tabwidget/tabbar.h
+++ b/src/lib/tabwidget/tabbar.h
@@ -39,6 +39,7 @@ public:
 
     TabWidget* tabWidget() const;
     void setVisible(bool visible);
+    void setForceHidden(bool hidden);
 
     void overrideTabTextColor(int index, QColor color);
     void restoreTabTextColor(int index);
@@ -118,6 +119,8 @@ private:
 
     QColor m_originalTabTextColor;
     QPoint m_dragStartPosition;
+
+    bool m_forceHidden;
 };
 
 #endif // TABBAR_H

--- a/src/plugins/TabManager/TabManager.pro
+++ b/src/plugins/TabManager/TabManager.pro
@@ -4,16 +4,19 @@ os2: TARGET = TabManPl
 
 SOURCES += tabmanagerplugin.cpp \
     tabmanagerwidget.cpp \
-    tabmanagerwidgetcontroller.cpp
+    tabmanagerwidgetcontroller.cpp \
+    tabmanagersettings.cpp
 
 HEADERS += tabmanagerplugin.h \
     tabmanagerwidget.h \
-    tabmanagerwidgetcontroller.h
+    tabmanagerwidgetcontroller.h \
+    tabmanagersettings.h
 
 RESOURCES += tabmanagerplugin.qrc
 
 FORMS += \
-    tabmanagerwidget.ui
+    tabmanagerwidget.ui \
+    tabmanagersettings.ui
 
 TRANSLATIONS += \
     translations/cs_CZ.ts \

--- a/src/plugins/TabManager/tabmanagerplugin.h
+++ b/src/plugins/TabManager/tabmanagerplugin.h
@@ -51,19 +51,38 @@ public:
     void showSettings(QWidget* parent = 0);
     void  populateExtensionsMenu(QMenu* menu);
 
+    enum ViewType {
+        ShowAsSideBar = 0,
+        ShowAsWindow = 1,
+        Undefined = -1
+    };
+
     void removeManagerWidget();
 
+    ViewType viewType();
+    void setViewType(ViewType type);
+
     static QString settingsPath();
+    void saveSettings();
+
+    bool asTabBarReplacement() const;
+    void setAsTabBarReplacement(bool yes);
 
 public slots:
     void insertManagerWidget();
 
+private slots:
+    void mainWindowCreated(BrowserWindow* window, bool refresh = true);
+
 private:
+    void setTabBarVisible(bool visible);
+
     TabManagerWidgetController* m_controller;
     TabManagerWidget* m_tabManagerWidget;
     static QString s_settingsPath;
-    QString m_viewType;
+    ViewType m_viewType;
     bool m_initState;
+    bool m_asTabBarReplacement;
 };
 
 #endif // TABMANAGERPLUGIN_H

--- a/src/plugins/TabManager/tabmanagersettings.cpp
+++ b/src/plugins/TabManager/tabmanagersettings.cpp
@@ -1,0 +1,32 @@
+#include "tabmanagersettings.h"
+#include "ui_tabmanagersettings.h"
+#include "tabmanagerplugin.h"
+
+TabManagerSettings::TabManagerSettings(TabManagerPlugin* plugin, QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::TabManagerSettings),
+    m_plugin(plugin)
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    ui->setupUi(this);
+
+    ui->sidebarRadio->setChecked(m_plugin->viewType() == TabManagerPlugin::ShowAsSideBar);
+    ui->windowRadio->setChecked(m_plugin->viewType() != TabManagerPlugin::ShowAsSideBar);
+    ui->checkBox->setChecked(m_plugin->asTabBarReplacement());
+
+    connect(ui->buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
+    connect(ui->buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+}
+
+TabManagerSettings::~TabManagerSettings()
+{
+    delete ui;
+}
+
+void TabManagerSettings::accept()
+{
+    m_plugin->setViewType(ui->sidebarRadio->isChecked() ? TabManagerPlugin::ShowAsSideBar : TabManagerPlugin::ShowAsWindow);
+    m_plugin->setAsTabBarReplacement(ui->checkBox->isChecked());
+
+    QDialog::accept();
+}

--- a/src/plugins/TabManager/tabmanagersettings.h
+++ b/src/plugins/TabManager/tabmanagersettings.h
@@ -1,0 +1,27 @@
+#ifndef TABMANAGERSETTINGS_H
+#define TABMANAGERSETTINGS_H
+
+#include <QDialog>
+
+namespace Ui {
+class TabManagerSettings;
+}
+class TabManagerPlugin;
+
+class TabManagerSettings : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit TabManagerSettings(TabManagerPlugin* plugin, QWidget *parent = 0);
+    ~TabManagerSettings();
+
+public slots:
+    void accept();
+
+private:
+    Ui::TabManagerSettings* ui;
+    TabManagerPlugin* m_plugin;
+};
+
+#endif // TABMANAGERSETTINGS_H

--- a/src/plugins/TabManager/tabmanagersettings.ui
+++ b/src/plugins/TabManager/tabmanagersettings.ui
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TabManagerSettings</class>
+ <widget class="QDialog" name="TabManagerSettings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>371</width>
+    <height>237</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Tab Manager Settings</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>View</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Please select view type:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="sidebarRadio">
+        <property name="text">
+         <string>SideBar</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="windowRadio">
+        <property name="text">
+         <string>Window</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; The &amp;quot;Window&amp;quot; type is recommended for managing lots of windows/tabs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox">
+     <property name="text">
+      <string>Use TabManager plugin as replacement for main TabBar.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/plugins/TabManager/tabmanagerwidgetcontroller.cpp
+++ b/src/plugins/TabManager/tabmanagerwidgetcontroller.cpp
@@ -21,6 +21,7 @@
 #include "browserwindow.h"
 #include "tabwidget.h"
 #include "mainapplication.h"
+#include "tabbar.h"
 
 #include <QDesktopWidget>
 #include <QStatusBar>
@@ -32,7 +33,6 @@
 TabManagerWidgetController::TabManagerWidgetController(QObject* parent)
     : SideBarInterface(parent)
     , m_defaultTabManager(0)
-    , m_viewType(ShowAsWindow)
     , m_groupType(TabManagerWidget::GroupByWindow)
 {
 }
@@ -91,16 +91,6 @@ QWidget* TabManagerWidgetController::createStatusBarIcon(BrowserWindow* mainWind
     m_actions.insert(mainWindow, showAction);
 
     return icon;
-}
-
-TabManagerWidgetController::ViewType TabManagerWidgetController::viewType()
-{
-    return m_viewType;
-}
-
-void TabManagerWidgetController::setViewType(ViewType type)
-{
-    m_viewType = type;
 }
 
 TabManagerWidget::GroupType TabManagerWidgetController::groupType()
@@ -163,19 +153,6 @@ void TabManagerWidgetController::removeStatusBarIcon(BrowserWindow* window)
     }
 }
 
-void TabManagerWidgetController::mainWindowCreated(BrowserWindow* window, bool refresh)
-{
-    if (window) {
-        addStatusBarIcon(window);
-        connect(window->tabWidget(), SIGNAL(currentChanged(int)), this, SIGNAL(requestRefreshTree()));
-        connect(window->tabWidget(), SIGNAL(pinStateChanged(int,bool)), this, SIGNAL(pinStateChanged(int,bool)));
-    }
-
-    if (refresh) {
-        emit requestRefreshTree();
-    }
-}
-
 void TabManagerWidgetController::mainWindowDeleted(BrowserWindow* window)
 {
     removeStatusBarIcon(window);
@@ -230,4 +207,9 @@ void TabManagerWidgetController::showSideBySide()
     defaultTabManager()->show();
     defaultTabManager()->activateWindow();
     defaultTabManager()->raise();
+}
+
+void TabManagerWidgetController::emitRefreshTree()
+{
+    emit requestRefreshTree();
 }

--- a/src/plugins/TabManager/tabmanagerwidgetcontroller.h
+++ b/src/plugins/TabManager/tabmanagerwidgetcontroller.h
@@ -27,11 +27,6 @@ class TabManagerWidgetController : public SideBarInterface
 {
     Q_OBJECT
 public:
-    enum ViewType {
-        ShowAsSideBar = 0,
-        ShowAsWindow = 1
-    };
-
     explicit TabManagerWidgetController(QObject* parent = 0);
     ~TabManagerWidgetController();
 
@@ -40,9 +35,6 @@ public:
     QWidget* createSideBarWidget(BrowserWindow* mainWindow);
 
     QWidget* createStatusBarIcon(BrowserWindow* mainWindow);
-
-    ViewType viewType();
-    void setViewType(ViewType type);
 
     TabManagerWidget::GroupType groupType();
     TabManagerWidget* createTabManagerWidget(BrowserWindow* mainClass, QWidget* parent = 0, bool defaultWidget = false);
@@ -54,14 +46,13 @@ public:
 
 public slots:
     void setGroupType(TabManagerWidget::GroupType type);
-    void mainWindowCreated(BrowserWindow* window, bool refresh = true);
     void mainWindowDeleted(BrowserWindow* window);
     void raiseTabManager();
     void showSideBySide();
+    void emitRefreshTree();
 
 private:
     TabManagerWidget* m_defaultTabManager;
-    ViewType m_viewType;
     TabManagerWidget::GroupType m_groupType;
 
     QHash<BrowserWindow*, QWidget*> m_statusBarIcons;


### PR DESCRIPTION
- Note: in `TabBar::setVisible()` we didn't need to
  check `(visible && m_window->isFullScreen())` because tabbar's
  visibility in fullscreen mode is managed by m_navigationContainer.