### PR TITLE
Fix id in appdata file

### DIFF
--- a/linux/appdata/qupzilla.appdata.xml
+++ b/linux/appdata/qupzilla.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <application>
- <id type="desktop">qupzila.desktop</id>
+ <id type="desktop">qupzilla.desktop</id>
  <metadata_license>CC0-1.0</metadata_license>
  <project_license>GPL-3.0+</project_license>
  <name>QupZilla</name>


### PR DESCRIPTION
The id did not match the name of the .desktop file because it had a typo.

Thanks!
