### PR TITLE
Disable save entry in menu for about and qupzilla scheme

### DIFF
--- a/src/lib/app/mainmenu.cpp
+++ b/src/lib/app/mainmenu.cpp
@@ -389,12 +389,18 @@ void MainMenu::aboutToShowFileMenu()
 #ifndef Q_OS_MAC
     m_actions[QSL("File/CloseWindow")]->setEnabled(mApp->windowCount() > 1);
 #endif
+    QUrl url = m_window->weView()->url();
+    bool enable = !url.isEmpty() &&
+        (url.scheme() != QLatin1String("about")) &&
+        (url.scheme() != QLatin1String("qupzilla"));
+    m_actions[QSL("File/SavePageAs")]->setEnabled(enable);
     m_actions[QSL("File/WorkOffline")]->setChecked(qzSettings->workOffline);
 }
 
 void MainMenu::aboutToHideFileMenu()
 {
     m_actions[QSL("File/CloseWindow")]->setEnabled(true);
+    m_actions[QSL("File/SavePageAs")]->setEnabled(true);
 }
 
 void MainMenu::aboutToShowViewMenu()


### PR DESCRIPTION
The pages addressed with the about and qupzilla scheme can currently not be saved. This means that selecting the save entry in the file menu has no effect. To prevent users from concluding that the saving should work but actually does not, the save entry is now disabled for these schemes.

Thanks!
