### PR TITLE
Fix duplicated RSS feed dialog having wrong parent

### DIFF
--- a/src/lib/rss/rssmanager.cpp
+++ b/src/lib/rss/rssmanager.cpp
@@ -165,7 +165,7 @@ void RSSManager::addFeed()
         return;
     }
 
-    addRssFeed(url, tr("New feed"), IconProvider::iconForUrl(url));
+    addRssFeed(this, url, tr("New feed"), IconProvider::iconForUrl(url));
     refreshTable();
 }
 
@@ -386,7 +386,7 @@ void RSSManager::finished()
     }
 }
 
-bool RSSManager::addRssFeed(const QUrl &url, const QString &title, const QIcon &icon)
+bool RSSManager::addRssFeed(QWidget* parent, const QUrl &url, const QString &title, const QIcon &icon)
 {
     if (url.isEmpty()) {
         return false;
@@ -415,7 +415,7 @@ bool RSSManager::addRssFeed(const QUrl &url, const QString &title, const QIcon &
         return true;
     }
 
-    QMessageBox::warning(getQupZilla(), tr("RSS feed duplicated"), tr("You already have this feed."));
+    QMessageBox::warning(parent, tr("RSS feed duplicated"), tr("You already have this feed."));
     return false;
 }
 

--- a/src/lib/rss/rssmanager.h
+++ b/src/lib/rss/rssmanager.h
@@ -47,7 +47,7 @@ public:
     explicit RSSManager(BrowserWindow* window, QWidget* parent = 0);
     ~RSSManager();
 
-    bool addRssFeed(const QUrl &url, const QString &title, const QIcon &icon);
+    bool addRssFeed(QWidget* parent, const QUrl &url, const QString &title, const QIcon &icon);
     void setMainWindow(BrowserWindow* window);
 
 public slots:

--- a/src/lib/rss/rssnotification.cpp
+++ b/src/lib/rss/rssnotification.cpp
@@ -161,7 +161,7 @@ void RSSNotification::addRss()
     }
 
     case Internal:
-        success = mApp->rssManager()->addRssFeed(m_url, m_title, m_view->icon());
+        success = mApp->rssManager()->addRssFeed(this, m_url, m_title, m_view->icon());
         if (success) {
             mApp->browsingLibrary()->showRSS(mApp->windows().at(0));
         }


### PR DESCRIPTION
The warning dialog about duplicated RSS feeds was opened with the main application window being the parent instead of the RSS feed window. This opened the warning dialog behind the RSS feed window which was confusing because the window needed to be moved away to find and close the dialog.

Thanks!
