### PR TITLE
Fix downloadmanager displaying wrong filename

### DIFF
--- a/src/lib/downloads/downloadmanager.cpp
+++ b/src/lib/downloads/downloadmanager.cpp
@@ -256,7 +256,7 @@ void DownloadManager::download(QWebEngineDownloadItem *downloadItem)
 
     // Create download item
     QListWidgetItem* listItem = new QListWidgetItem(ui->list);
-    DownloadItem* downItem = new DownloadItem(listItem, downloadItem, QFileInfo(downloadPath).absolutePath(), fileName, openFile, this);
+    DownloadItem* downItem = new DownloadItem(listItem, downloadItem, QFileInfo(downloadPath).absolutePath(), QFileInfo(downloadPath).fileName(), openFile, this);
     connect(downItem, SIGNAL(deleteItem(DownloadItem*)), this, SLOT(deleteItem(DownloadItem*)));
     connect(downItem, SIGNAL(downloadFinished(bool)), this, SLOT(downloadFinished(bool)));
     ui->list->setItemWidget(listItem, downItem);


### PR DESCRIPTION
Trying to save image file with custom name instead default one (generated from URL).
![custom](http://i.imgur.com/V0BEetv.png)
Albeit file saves with custom file name, download manager prefers default one.
![default](http://i.imgur.com/PoZSdPU.png) 