### PR TITLE
Fix endless loading invalid webpages in speed-dial

### DIFF
--- a/src/lib/data/html/speeddial.html
+++ b/src/lib/data/html/speeddial.html
@@ -287,8 +287,6 @@ function setTitleToUrl(url, title) {
         var span = box.getElementsByTagName('span')[0];
         span.innerText = title;
     }
-
-    external.speedDial.changed(allPages());
 }
 
 function setImageToUrl(url, img_source) {


### PR DESCRIPTION
This can be naive approach, but I believe *external.speedDial.changed(allPages())* call is just redundant. More than that, it screws everything, making endless loop when added URL is invalid.

Closes #1763 .