### PR TITLE
Default to NoProxy rather than HttpProxy

### DIFF
--- a/src/lib/network/networkproxyfactory.cpp
+++ b/src/lib/network/networkproxyfactory.cpp
@@ -62,7 +62,7 @@ bool WildcardMatcher::match(const QString &str) const
 NetworkProxyFactory::NetworkProxyFactory()
     : QNetworkProxyFactory()
     , m_proxyPreference(SystemProxy)
-    , m_proxyType(QNetworkProxy::HttpProxy)
+    , m_proxyType(QNetworkProxy::NoProxy)
     , m_port(0)
     , m_httpsPort(0)
     , m_useDifferentProxyForHttps(false)
@@ -74,7 +74,7 @@ void NetworkProxyFactory::loadSettings()
     Settings settings;
     settings.beginGroup("Web-Proxy");
     m_proxyPreference = ProxyPreference(settings.value("UseProxy", SystemProxy).toInt());
-    m_proxyType = QNetworkProxy::ProxyType(settings.value("ProxyType", QNetworkProxy::HttpProxy).toInt());
+    m_proxyType = QNetworkProxy::ProxyType(settings.value("ProxyType", QNetworkProxy::NoProxy).toInt());
     m_useDifferentProxyForHttps = settings.value("UseDifferentProxyForHttps", false).toBool();
 
     m_hostName = settings.value("HostName", QString()).toString();

--- a/src/lib/preferences/preferences.cpp
+++ b/src/lib/preferences/preferences.cpp
@@ -420,7 +420,7 @@ Preferences::Preferences(BrowserWindow* window)
 
     // Proxy Configuration
     settings.beginGroup("Web-Proxy");
-    QNetworkProxy::ProxyType proxyType = QNetworkProxy::ProxyType(settings.value("ProxyType", QNetworkProxy::HttpProxy).toInt());
+    QNetworkProxy::ProxyType proxyType = QNetworkProxy::ProxyType(settings.value("ProxyType", QNetworkProxy::NoProxy).toInt());
 
     ui->systemProxy->setChecked(proxyType == QNetworkProxy::NoProxy);
     ui->manualProxy->setChecked(proxyType != QNetworkProxy::NoProxy);

--- a/src/plugins/StatusBarIcons/sbi_networkproxy.cpp
+++ b/src/plugins/StatusBarIcons/sbi_networkproxy.cpp
@@ -89,7 +89,7 @@ void SBI_NetworkProxy::loadFromSettings(const QSettings &settings)
     m_username = settings.value("Username", QString()).toString();
     m_password = settings.value("Password", QString()).toString();
 
-    m_type = QNetworkProxy::ProxyType(settings.value("ProxyType", QNetworkProxy::HttpProxy).toInt());
+    m_type = QNetworkProxy::ProxyType(settings.value("ProxyType", QNetworkProxy::NoProxy).toInt());
 }
 
 void SBI_NetworkProxy::saveToSettings(QSettings &settings) const


### PR DESCRIPTION
The HttpProxy setting neither makes sense nor works without a concrete
proxy being set. So default to something that has any chance of working
without manual configuration. If you need an HTTP proxy, you will have
to configure it anyway.