### PR TITLE
Allow to split shared data from prefix

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -197,6 +197,12 @@ Available Defines
                           example:
                           $ export QUPZILLA_PREFIX="/usr"
 
+     SHARE_FOLDER         You can define the path of the share folder, i.e. /usr/share
+                          QupZilla will then use SHARE_FOLDER/qupzilla as datadir,
+                          SHARE_FOLDER/applications for desktop launcher and
+                          SHARE_FOLDER/pixmaps for the icon. By default it is not defined and
+                          files will be installed as described above.
+
      DISABLE_DBUS         Build without QtDBus module. Native desktop notifications
                           will be disabled.
 

--- a/src/defines.pri
+++ b/src/defines.pri
@@ -23,6 +23,7 @@ d_disable_dbus = $$(DISABLE_DBUS)
 d_disable_updates_check = $$(DISABLE_UPDATES_CHECK)
 d_debug_build = $$(DEBUG_BUILD)
 d_prefix = $$(QUPZILLA_PREFIX)
+d_share = $$(SHARE_FOLDER)
 
 equals(d_no_system_datapath, "true") { DEFINES *= NO_SYSTEM_DATAPATH }
 equals(d_kde_integration, "true") { DEFINES *= KDE_INTEGRATION }
@@ -63,6 +64,7 @@ haiku-* {
     launcher_folder = /usr/share/applications
     icon_folder = /usr/share/pixmaps
     hicolor_folder = /usr/share/icons/hicolor
+    share_folder = /usr/share
 
     !equals(d_prefix, "") {
         binary_folder = "$$d_prefix"/bin
@@ -71,6 +73,15 @@ haiku-* {
         launcher_folder = "$$d_prefix"/share/applications
         icon_folder = "$$d_prefix"/share/pixmaps
         hicolor_folder = "$$d_prefix"/share/icons/hicolor
+        share_folder = "$$d_prefix"/share
+    }
+
+    !equals(d_share, "") {
+        data_folder = "$$d_share"/qupzilla
+        launcher_folder = "$$d_share"/applications
+        icon_folder = "$$d_share"/pixmaps
+        hicolor_folder = "$$d_share"/icons/hicolor
+        share_folder = "$$d_share"
     }
 
     !equals(d_use_lib_path, ""):library_folder = $$d_use_lib_path

--- a/src/defines.pri
+++ b/src/defines.pri
@@ -60,29 +60,23 @@ haiku-* {
     library_folder = /usr/lib
     arch_lib_path = /usr/lib/$${QT_ARCH}-linux-gnu
     exists($$arch_lib_path): library_folder = $$arch_lib_path
-    data_folder = /usr/share/qupzilla
-    launcher_folder = /usr/share/applications
-    icon_folder = /usr/share/pixmaps
-    hicolor_folder = /usr/share/icons/hicolor
+    # Define a reasonable default for share_folder
     share_folder = /usr/share
 
     !equals(d_prefix, "") {
         binary_folder = "$$d_prefix"/bin
         library_folder = "$$d_prefix"/lib
-        data_folder = "$$d_prefix"/share/qupzilla
-        launcher_folder = "$$d_prefix"/share/applications
-        icon_folder = "$$d_prefix"/share/pixmaps
-        hicolor_folder = "$$d_prefix"/share/icons/hicolor
         share_folder = "$$d_prefix"/share
     }
 
     !equals(d_share, "") {
-        data_folder = "$$d_share"/qupzilla
-        launcher_folder = "$$d_share"/applications
-        icon_folder = "$$d_share"/pixmaps
-        hicolor_folder = "$$d_share"/icons/hicolor
         share_folder = "$$d_share"
     }
+
+    data_folder = $$share_folder/qupzilla
+    launcher_folder = $$share_folder/applications
+    icon_folder = $$share_folder/pixmaps
+    hicolor_folder = $$share_folder/icons/hicolor
 
     !equals(d_use_lib_path, ""):library_folder = $$d_use_lib_path
 

--- a/src/install.pri
+++ b/src/install.pri
@@ -44,10 +44,10 @@ mac {
     ico256.path = $$hicolor_folder/256x256/apps
 
     bashcompletion.files = $$PWD/../linux/completion/qupzilla
-    bashcompletion.path = /usr/share/bash-completion/completions
+    bashcompletion.path = $$share_folder/usr/share/bash-completion/completions
 
     appdata.files = $$PWD/../linux/appdata/qupzilla.appdata.xml
-    appdata.path = /usr/share/appdata
+    appdata.path = $$share_folder/appdata
 
 
     INSTALLS += target target1 target2 target3


### PR DESCRIPTION
My distribution uses a prefix that is different from /usr for cross-compile capability.
However, shared data should still go to /usr/share as expected. Thus qupzilla installs to the wrong directories.
The changes fix this, so that one can now define where the data should go explicitely. If not specified it should behave like previously.

At the same time I replaced some hardcoded paths.