### PR TITLE
Fix tabwidget signals connect

### DIFF
--- a/src/lib/tabwidget/tabwidget.cpp
+++ b/src/lib/tabwidget/tabwidget.cpp
@@ -397,7 +397,7 @@ int TabWidget::addView(WebTab* tab)
     tab->attach(m_window);
 
     connect(tab->webView(), SIGNAL(wantsCloseTab(int)), this, SLOT(closeTab(int)));
-    connect(tab->webView(), SIGNAL(changed()), this, SIGNAL(changed()));
+    connect(tab->webView(), SIGNAL(urlChanged(QUrl)), this, SIGNAL(changed()));
     connect(tab->webView(), SIGNAL(ipChanged(QString)), m_window->ipLabel(), SLOT(setText(QString)));
 
     return index;


### PR DESCRIPTION
When trying to detach tab, having following debug output
```
Object::connect: No such signal TabbedWebView::changed() in ../../../src/lib/tabwidget/tabwidget.cpp:400
QObject::connect: (receiver name: 'tabwidget')

```