### PR TITLE
Change background image instantly and for all speed dials

### DIFF
--- a/src/lib/plugins/speeddial.cpp
+++ b/src/lib/plugins/speeddial.cpp
@@ -305,6 +305,8 @@ void SpeedDial::setBackgroundImage(const QString &image)
 {
     m_backgroundImage = QzTools::pixmapToDataUrl(QPixmap(QUrl(image).toLocalFile())).toString();
     m_backgroundImageUrl = image;
+
+    emit pagesChanged();
 }
 
 void SpeedDial::setBackgroundImageSize(const QString &size)


### PR DESCRIPTION
When we click "Apply" after selecting background image, it won't be updated for already opened speed-dials. Need to open new tab to make sure background was changed.