### PR TITLE
added sh to OS X build instructions

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -48,7 +48,7 @@ MAC OS X
   After successful compilation, you need to run macdeploy.sh script to correctly
   build the application bundle. You will do it with following command:
 
-    $ ./mac/macdeploy.sh <path-to-macdeployqt>
+    $ sh ./mac/macdeploy.sh <path-to-macdeployqt>
 
   You need to specify path to macdeployqt (usually in QTDIR/bin/macdeployqt) only
   if it is not in PATH.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ On Linux/Unix: To install QupZilla, run this command: (it may be necessary to ru
 
 On Mac OS X: To deploy QupZilla in dmg image, run this command:
 
-    $ ./mac/macdeploy.sh full-path-to-macdeployqt
+    $ sh ./mac/macdeploy.sh full-path-to-macdeployqt
 
 You need to specify path to `macdeployqt` only if it is not in PATH.
 


### PR DESCRIPTION
Without the `sh` I get `command not found`.