### PR TITLE
fixed overlapping bookmarks on the toolbar; issue #1896

### DIFF
--- a/src/lib/bookmarks/bookmarkstoolbar.cpp
+++ b/src/lib/bookmarks/bookmarkstoolbar.cpp
@@ -41,7 +41,6 @@ BookmarksToolbar::BookmarksToolbar(BrowserWindow* window, QWidget* parent)
 
     m_layout = new QHBoxLayout(this);
     m_layout->setMargin(1);
-    m_layout->setSpacing(0);
     setLayout(m_layout);
 
     // Set some sane value, will be updated to correct value on first added button


### PR DESCRIPTION
Letting Qt decide the spacing fixes the problem; and there appears to be 0 spacing anyhow.