### PR TITLE
Use `rev-parse` instead of `show-ref`

### DIFF
--- a/git_hooks/post-checkout
+++ b/git_hooks/post-checkout
@@ -2,4 +2,4 @@
 #
 # Writes git revision into git_revision file
 #
-git show-ref refs/heads/master | cut -d " " -f 1  > git_revision
+git rev-parse HEAD | cut -d " " -f 1  > git_revision

--- a/git_hooks/post-checkout
+++ b/git_hooks/post-checkout
@@ -2,4 +2,4 @@
 #
 # Writes git revision into git_revision file
 #
-git rev-parse HEAD | cut -d " " -f 1  > git_revision
+git rev-parse HEAD > git_revision

--- a/git_hooks/post-commit
+++ b/git_hooks/post-commit
@@ -2,4 +2,4 @@
 #
 # Writes git revision into git_revision file
 #
-git show-ref refs/heads/master | cut -d " " -f 1  > git_revision
+git rev-parse HEAD | cut -d " " -f 1  > git_revision

--- a/git_hooks/post-commit
+++ b/git_hooks/post-commit
@@ -2,4 +2,4 @@
 #
 # Writes git revision into git_revision file
 #
-git rev-parse HEAD | cut -d " " -f 1  > git_revision
+git rev-parse HEAD > git_revision

--- a/git_hooks/post-merge
+++ b/git_hooks/post-merge
@@ -2,4 +2,4 @@
 #
 # Writes git revision into git_revision file
 #
-git show-ref refs/heads/master | cut -d " " -f 1  > git_revision
+git rev-parse HEAD | cut -d " " -f 1  > git_revision

--- a/git_hooks/post-merge
+++ b/git_hooks/post-merge
@@ -2,4 +2,4 @@
 #
 # Writes git revision into git_revision file
 #
-git rev-parse HEAD | cut -d " " -f 1  > git_revision
+git rev-parse HEAD > git_revision

--- a/scripts/getrevision.sh
+++ b/scripts/getrevision.sh
@@ -3,7 +3,7 @@
 REV=""
 
 if [ -e "/usr/bin/git" ] && ([ -e ".git" ] || [ -e "../.git" ]); then
-    REV=`git rev-parse HEAD | cut -d " " -f 1`
+    REV=`git rev-parse HEAD`
 elif [ -e "git_revision" ]; then
     REV=`cat git_revision`
 fi

--- a/scripts/getrevision.sh
+++ b/scripts/getrevision.sh
@@ -3,7 +3,7 @@
 REV=""
 
 if [ -e "/usr/bin/git" ] && ([ -e ".git" ] || [ -e "../.git" ]); then
-    REV=`git show-ref refs/heads/master | cut -d " " -f 1`
+    REV=`git rev-parse HEAD | cut -d " " -f 1`
 elif [ -e "git_revision" ]; then
     REV=`cat git_revision`
 fi


### PR DESCRIPTION
* Dev builds currently use masters commit ref and makes it difficult to determine which version is really installed with About &rarr; Help. Use the current HEAD when generating the `Makefile`s for `DGIT_REVISION`

**NOTES**
* The bash scripts are somewhat duplicated with the unused `--short` parameter but omitted at this time in case a long hash is wanted.
* `make distclean` is still needed since those defines are hard-coded into those affected `Makefile`s