### PR TITLE
GM: Detect properly the UserScript metadata block on parse

### DIFF
--- a/src/plugins/GreaseMonkey/gm_script.cpp
+++ b/src/plugins/GreaseMonkey/gm_script.cpp
@@ -238,7 +238,7 @@ void GM_Script::parseScript()
 
     const QString fileData = QString::fromUtf8(file.readAll());
 
-    QzRegExp rx(QSL("// ==UserScript==(.*)// ==/UserScript=="));
+    QzRegExp rx(QSL("(?:^|\\n)// ==UserScript==(.*)\\n// ==/UserScript==(?:\\n|$)"));
     rx.indexIn(fileData);
     QString metadataBlock = rx.cap(1).trimmed();
 


### PR DESCRIPTION
* Eliminates some false positives

**NOTES**
* Needs further followup discussion on creator standards compliance but this is a start

---

PR READY