### PR TITLE
Fix position of SpeedDial items in RTL

### DIFF
--- a/src/lib/data/html/speeddial.html
+++ b/src/lib/data/html/speeddial.html
@@ -445,7 +445,7 @@ function enableCentering()
 function disableCentering()
 {
     $('#quickdial div.entry').css({
-        float: 'left',
+        float: '%LEFT_STR%',
         display: 'block'
     });
 }


### PR DESCRIPTION
The position of the items in Speed Dial is mirrored as the float attribute wasn't changed according to the layout.