### PR TITLE
GM WIN: Add CR to detection

### DIFF
--- a/src/plugins/GreaseMonkey/gm_script.cpp
+++ b/src/plugins/GreaseMonkey/gm_script.cpp
@@ -238,7 +238,7 @@ void GM_Script::parseScript()
 
     const QString fileData = QString::fromUtf8(file.readAll());
 
-    QzRegExp rx(QSL("(?:^|[\\r\\n])// ==UserScript==(.*)(?:[\\r\\n]|\\r\\n)// ==/UserScript==(?:[\\r\\n]|$)"));
+    QzRegExp rx(QSL("(?:^|[\\r\\n])// ==UserScript==(.*)(?:\\r\\n|[\\r\\n])// ==/UserScript==(?:[\\r\\n]|$)"));
     rx.indexIn(fileData);
     QString metadataBlock = rx.cap(1).trimmed();
 
@@ -248,7 +248,7 @@ void GM_Script::parseScript()
     }
 
     QStringList requireList;
-    QzRegExp rxNL(QSL("(?:[\\r\\n]|\\r\\n)"));
+    QzRegExp rxNL(QSL("(?:\\r\\n|[\\r\\n])"));
 
     const QStringList lines = metadataBlock.split(rxNL, QString::SkipEmptyParts);
     foreach (QString line, lines) {

--- a/src/plugins/GreaseMonkey/gm_script.cpp
+++ b/src/plugins/GreaseMonkey/gm_script.cpp
@@ -238,7 +238,7 @@ void GM_Script::parseScript()
 
     const QString fileData = QString::fromUtf8(file.readAll());
 
-    QzRegExp rx(QSL("(?:^|[\\r\\n])// ==UserScript==(.*)[\\r\\n]// ==/UserScript==(?:[\\r\\n]|$)"));
+    QzRegExp rx(QSL("(?:^|[\\r\\n])// ==UserScript==(.*)(?:[\\r\\n]|\\r\\n)// ==/UserScript==(?:[\\r\\n]|$)"));
     rx.indexIn(fileData);
     QString metadataBlock = rx.cap(1).trimmed();
 
@@ -248,8 +248,9 @@ void GM_Script::parseScript()
     }
 
     QStringList requireList;
+    QzRegExp rxNL(QSL("(?:[\\r\\n]|\\r\\n)"));
 
-    const QStringList lines = metadataBlock.split(QLatin1Char('\n'), QString::SkipEmptyParts);
+    const QStringList lines = metadataBlock.split(rxNL, QString::SkipEmptyParts);
     foreach (QString line, lines) {
         if (!line.startsWith(QLatin1String("// @"))) {
             continue;

--- a/src/plugins/GreaseMonkey/gm_script.cpp
+++ b/src/plugins/GreaseMonkey/gm_script.cpp
@@ -238,7 +238,7 @@ void GM_Script::parseScript()
 
     const QString fileData = QString::fromUtf8(file.readAll());
 
-    QzRegExp rx(QSL("(?:^|\\n)// ==UserScript==(.*)\\n// ==/UserScript==(?:\\n|$)"));
+    QzRegExp rx(QSL("(?:^|[\\r\\n])// ==UserScript==(.*)[\\r\\n]// ==/UserScript==(?:[\\r\\n]|$)"));
     rx.indexIn(fileData);
     QString metadataBlock = rx.cap(1).trimmed();
 


### PR DESCRIPTION
Saving in Notepad++ with Windows line ending prevents script injection

Post fix for #1964 and some vague references at https://github.com/QupZilla/qupzilla/commit/ce67c7a455a58b3cf64491054688e4c9e9593c3a

PR NEEDS TESTING under Windows before it's ready. This is the standard GM fix which appears to be needed in Qt string handling as well... @nowrep please compile it and test under Windows before merging. *(OS X and Linux distros appear good to go)*

---

NOTE: In plain WIN7 NOTEPAD.EXE it will show up visibly as a normal looking .user.js however when NIX/OSX line endings are present it will be all on one line.

---

PR READY confirmation [here](https://github.com/QupZilla/qupzilla/commit/ce67c7a455a58b3cf64491054688e4c9e9593c3a#commitcomment-18196952) from pejakm