### PR TITLE
Add short command line for all options

### DIFF
--- a/src/lib/app/commandlineoptions.cpp
+++ b/src/lib/app/commandlineoptions.cpp
@@ -43,36 +43,36 @@ void CommandLineOptions::parseActions()
     profileOption.setValueName(QSL("profileName"));
     profileOption.setDescription(QSL("Starts with specified profile."));
 
-    QCommandLineOption noExtensionsOption(QSL("no-extensions"));
+    QCommandLineOption noExtensionsOption(QStringList({QSL("e"), QSL("no-extensions")}));
     noExtensionsOption.setDescription(QSL("Starts without extensions."));
 
-    QCommandLineOption privateBrowsingOption(QSL("private-browsing"));
+    QCommandLineOption privateBrowsingOption(QStringList({QSL("i"), QSL("private-browsing")}));
     privateBrowsingOption.setDescription(QSL("Starts private browsing."));
 
-    QCommandLineOption portableOption(QSL("portable"));
+    QCommandLineOption portableOption(QStringList({QSL("o"), QSL("portable")}));
     portableOption.setDescription(QSL("Starts in portable mode."));
 
-    QCommandLineOption noRemoteOption(QSL("no-remote"));
+    QCommandLineOption noRemoteOption(QStringList({QSL("r"), QSL("no-remote")}));
     noRemoteOption.setDescription(QSL("Starts new browser instance."));
 
-    QCommandLineOption newTabOption(QSL("new-tab"));
+    QCommandLineOption newTabOption(QStringList({QSL("t"), QSL("new-tab")}));
     newTabOption.setDescription(QSL("Opens new tab."));
 
-    QCommandLineOption newWindowOption(QSL("new-window"));
+    QCommandLineOption newWindowOption(QStringList({QSL("w"), QSL("new-window")}));
     newWindowOption.setDescription(QSL("Opens new window."));
 
-    QCommandLineOption downloadManagerOption(QSL("download-manager"));
+    QCommandLineOption downloadManagerOption(QStringList({QSL("d"), QSL("download-manager")}));
     downloadManagerOption.setDescription(QSL("Opens download manager."));
 
-    QCommandLineOption currentTabOption(QSL("current-tab"));
+    QCommandLineOption currentTabOption(QStringList({QSL("c"), QSL("current-tab")}));
     currentTabOption.setValueName(QSL("URL"));
     currentTabOption.setDescription(QSL("Opens URL in current tab."));
 
-    QCommandLineOption openWindowOption(QSL("open-window"));
+    QCommandLineOption openWindowOption(QStringList({QSL("u"), QSL("open-window")}));
     openWindowOption.setValueName(QSL("URL"));
     openWindowOption.setDescription(QSL("Opens URL in new window."));
 
-    QCommandLineOption fullscreenOption(QSL("fullscreen"));
+    QCommandLineOption fullscreenOption(QStringList({QSL("f"), QSL("fullscreen")}));
     fullscreenOption.setDescription(QSL("Toggles fullscreen."));
 
     // Parser


### PR DESCRIPTION
Described at issue #2020 as requested by @nowrep.

The switch to [**QCommandLineParser**](http://doc.qt.io/qt-5/qcommandlineparser.html) forced the use of single letter for single dash command line.
So, short options like -pb for private browsing are not allowed anymore.

Since using more than a letter for short options is not possible anymore, i suggest to introduce single letter short options for any (or the most used/complex) command line option.

Ex.:

```
Options:
  -h, --help                   Displays this help.
  -v, --version                Displays version information.
  -a, --authors                Displays author information.
  -p, --profile <profileName>  Starts with specified profile.
  -e, --no-extensions          Starts without extensions.
  -i, --private-browsing       Starts private browsing.
  -o, --portable               Starts in portable mode.
  -r, --no-remote              Starts new browser instance.
  -t, --new-tab                Opens new tab.
  -w, --new-window             Opens new window.
  -d, --download-manager       Opens download manager.
  -c, --current-tab <URL>      Opens URL in current tab.
  -u, --open-window <URL>      Opens URL in new window.
  -f, --fullscreen             Toggles fullscreen.

```
Since there are words starting with the same letter, a less intuitive but working one have to be choosen.
So, using bold letters to clarify the choice:
**h**elp
**v**ersion
**a**uthors
**p**rofile
no-**e**xtensions
pr**i**vate-browsing
p**o**rtable
no-**r**emote
new-**t**ab
new-**w**indow
**d**ownload-manager
**c**urrent-tab <URL>
open-window <**U**RL>
**f**ullscreen

Uppercase letters may be used too.