### PR TITLE
Show Bookmark Toolbar when Location Bar gets focus

### DIFF
--- a/src/lib/app/browserwindow.cpp
+++ b/src/lib/app/browserwindow.cpp
@@ -745,6 +745,17 @@ void BrowserWindow::toggleShowStatusBar()
 
 }
 
+void BrowserWindow::showBookmarksToolbar(bool show)
+{
+    // Method for quick show/hiding of Bookmarks Toolbar
+    // Doesn't need updates and settings to be modified
+    // TODO: animate showing/hiding for better look
+
+    if (Settings().value("Browser-View-Settings/instantBookmarksToolbar").toBool()) {
+        m_bookmarksToolbar->setVisible(show);
+    }
+}
+
 void BrowserWindow::toggleShowBookmarksToolbar()
 {
     setUpdatesEnabled(false);
@@ -754,6 +765,7 @@ void BrowserWindow::toggleShowBookmarksToolbar()
     setUpdatesEnabled(true);
 
     Settings().setValue("Browser-View-Settings/showBookmarksToolbar", m_bookmarksToolbar->isVisible());
+    Settings().setValue("Browser-View-Settings/instantBookmarksToolbar", false);
 }
 
 void BrowserWindow::toggleShowNavigationToolbar()
@@ -897,7 +909,7 @@ void BrowserWindow::createToolbarsMenu(QMenu* menu)
 
     action = menu->addAction(tr("&Bookmarks Toolbar"), this, SLOT(toggleShowBookmarksToolbar()));
     action->setCheckable(true);
-    action->setChecked(m_bookmarksToolbar->isVisible());
+    action->setChecked(Settings().value("Browser-View-Settings/showBookmarksToolbar").toBool());
 
     menu->addSeparator();
 

--- a/src/lib/app/browserwindow.h
+++ b/src/lib/app/browserwindow.h
@@ -127,6 +127,7 @@ public slots:
 
     void toggleShowMenubar();
     void toggleShowStatusBar();
+    void showBookmarksToolbar(bool show);
     void toggleShowBookmarksToolbar();
     void toggleShowNavigationToolbar();
     void toggleTabsOnTop(bool enable);

--- a/src/lib/navigation/locationbar.cpp
+++ b/src/lib/navigation/locationbar.cpp
@@ -403,6 +403,8 @@ void LocationBar::focusInEvent(QFocusEvent* event)
 
     clearTextFormat();
     LineEdit::focusInEvent(event);
+
+    m_window->showBookmarksToolbar(true);
 }
 
 void LocationBar::focusOutEvent(QFocusEvent* event)
@@ -422,6 +424,8 @@ void LocationBar::focusOutEvent(QFocusEvent* event)
     }
 
     refreshTextFormat();
+
+    m_window->showBookmarksToolbar(false);
 }
 
 void LocationBar::dropEvent(QDropEvent* event)

--- a/src/lib/preferences/preferences.cpp
+++ b/src/lib/preferences/preferences.cpp
@@ -217,7 +217,7 @@ Preferences::Preferences(BrowserWindow* window)
     // NOTE: instantBookmarksToolbar and showBookmarksToolbar cannot be both enabled at the same time
     ui->instantBookmarksToolbar->setChecked(settings.value("instantBookmarksToolbar", false).toBool());
     ui->showBookmarksToolbar->setChecked(settings.value("showBookmarksToolbar", true).toBool());
-    ui->instantBookmarksToolbar->setDisabled(settings.value("showBookmarksToolbar").toBool());
+    ui->instantBookmarksToolbar->setDisabled(settings.value("showBookmarksToolbar", true).toBool());
     ui->showBookmarksToolbar->setDisabled(settings.value("instantBookmarksToolbar").toBool());
     connect(ui->instantBookmarksToolbar, SIGNAL(toggled(bool)), ui->showBookmarksToolbar, SLOT(setDisabled(bool)));
     connect(ui->showBookmarksToolbar, SIGNAL(toggled(bool)), ui->instantBookmarksToolbar, SLOT(setDisabled(bool)));

--- a/src/lib/preferences/preferences.cpp
+++ b/src/lib/preferences/preferences.cpp
@@ -214,7 +214,13 @@ Preferences::Preferences(BrowserWindow* window)
     //APPEREANCE
     settings.beginGroup("Browser-View-Settings");
     ui->showStatusbar->setChecked(settings.value("showStatusBar", false).toBool());
+    // NOTE: instantBookmarksToolbar and showBookmarksToolbar cannot be both enabled at the same time
+    ui->instantBookmarksToolbar->setChecked(settings.value("instantBookmarksToolbar", false).toBool());
     ui->showBookmarksToolbar->setChecked(settings.value("showBookmarksToolbar", true).toBool());
+    ui->instantBookmarksToolbar->setDisabled(settings.value("showBookmarksToolbar").toBool());
+    ui->showBookmarksToolbar->setDisabled(settings.value("instantBookmarksToolbar").toBool());
+    connect(ui->instantBookmarksToolbar, SIGNAL(toggled(bool)), ui->showBookmarksToolbar, SLOT(setDisabled(bool)));
+    connect(ui->showBookmarksToolbar, SIGNAL(toggled(bool)), ui->instantBookmarksToolbar, SLOT(setDisabled(bool)));
     ui->showNavigationToolbar->setChecked(settings.value("showNavigationToolbar", true).toBool());
     ui->showHome->setChecked(settings.value("showHomeButton", true).toBool());
     ui->showBackForward->setChecked(settings.value("showBackForwardButtons", true).toBool());
@@ -853,6 +859,7 @@ void Preferences::saveSettings()
     //WINDOW
     settings.beginGroup("Browser-View-Settings");
     settings.setValue("showStatusBar", ui->showStatusbar->isChecked());
+    settings.setValue("instantBookmarksToolbar", ui->instantBookmarksToolbar->isChecked());
     settings.setValue("showBookmarksToolbar", ui->showBookmarksToolbar->isChecked());
     settings.setValue("showNavigationToolbar", ui->showNavigationToolbar->isChecked());
     settings.setValue("showHomeButton", ui->showHome->isChecked());

--- a/src/lib/preferences/preferences.ui
+++ b/src/lib/preferences/preferences.ui
@@ -591,6 +591,13 @@
                    </property>
                   </widget>
                  </item>
+                 <item row="3" column="0">
+                  <widget class="QCheckBox" name="instantBookmarksToolbar">
+                   <property name="text">
+                    <string>Enable instant Bookmarks ToolBar</string>
+                   </property>
+                  </widget>
+                 </item>
                 </layout>
                </item>
                <item row="2" column="0" colspan="2">


### PR DESCRIPTION
Optional behaviour providing quick access to bookmarks without wasting the vertical space

Resembles old Opera's style of accessing the bookmarks with the "Quick Bar"