### PR TITLE
Add initial printing support with QtWebEngine >= 5.7.0

### DIFF
--- a/src/lib/app/browserwindow.cpp
+++ b/src/lib/app/browserwindow.cpp
@@ -635,25 +635,34 @@ void BrowserWindow::printPage()
         if (dialog->printer()->outputFormat() == QPrinter::PdfFormat) {
             weView()->page()->printToPdf(dialog->printer()->outputFileName(), dialog->printer()->pageLayout());
         } else {
-            QTemporaryFile tempFile(QDir::tempPath() + QSL("/QupZillaPrintXXXXXX.pdf"));
-            tempFile.setAutoRemove(false);
-            if (tempFile.open()) { // create the file name, and the file to reserve it
-                tempFile.close(); // close, but don't delete the file
-                weView()->page()->printToPdf(tempFile.fileName(), dialog->printer()->pageLayout());
+            QString printerName = dialog->printer()->printerName();
+            weView()->page()->printToPdf([=](const QByteArray &data) {
+                if (!data.isEmpty()) {
+                    QTemporaryFile tempFile(QDir::tempPath() + QSL("/QupZillaPrintXXXXXX.pdf"));
+                    tempFile.setAutoRemove(false);
+                    if (tempFile.open()) {
+                        qint64 bytesWritten = tempFile.write(data);
+                        tempFile.close();
+                        if (bytesWritten == data.size()) {
 #ifdef Q_OS_WIN
-                // This may bring up a PDF viewer window, and even keep it open, but it is the best we can do without adding third-party dependencies.
-                // lpr is not installed by default on Windows, and it also can only print PDF if the printer handles it in hardware.
-                ShellExecuteW(winId(), L"printto", tempFile.fileName().constData(), ('"' + dialog->printer()->printerName() + '"').constData(), NULL, SW_HIDE);
-                // TODO: When can we delete the file?
+                            // This may bring up a PDF viewer window, and even keep it open, but it is the best we can do without adding third-party dependencies.
+                            // lpr is not installed by default on Windows, and it also can only print PDF if the printer handles it in hardware.
+                            ShellExecuteW(winId(), L"printto", tempFile.fileName().constData(), ('"' + printerName + '"').constData(), NULL, SW_HIDE);
+                            // TODO: When can we delete the file?
 #else
-                // -r automatically deletes the file after printing it.
-                // TODO: We should probably pass some additional options such as media size. See, e.g., Okular's fileprinter.cpp.
-                if (QProcess::execute(QSL("lpr"), QStringList() << QSL("-P") << dialog->printer()->printerName() << QSL("-r") << tempFile.fileName()) != 0) {
-                    // lpr failed, so remove the temporary file in case it still exists.
-                    tempFile.remove();
-                }
+                            // -r automatically deletes the file after printing it.
+                            // TODO: We should probably pass some additional options such as media size. See, e.g., Okular's fileprinter.cpp.
+                            if (QProcess::execute(QSL("lpr"), QStringList() << QSL("-P") << printerName << QSL("-r") << tempFile.fileName()) != 0) {
+                                // lpr failed, so remove the temporary file in case it still exists.
+                                tempFile.remove();
+                            }
 #endif
-            }
+                        } else {
+                            tempFile.remove();
+                        }
+                    }
+                }
+            }, dialog->printer()->pageLayout());
         }
     }
 

--- a/src/lib/app/browserwindow.cpp
+++ b/src/lib/app/browserwindow.cpp
@@ -638,27 +638,42 @@ void BrowserWindow::printPage()
             QString printerName = dialog->printer()->printerName();
             weView()->page()->printToPdf([=](const QByteArray &data) {
                 if (!data.isEmpty()) {
-                    QTemporaryFile tempFile(QDir::tempPath() + QSL("/QupZillaPrintXXXXXX.pdf"));
-                    tempFile.setAutoRemove(false);
-                    if (tempFile.open()) {
-                        qint64 bytesWritten = tempFile.write(data);
-                        tempFile.close();
+                    QTemporaryFile *tempFile = new QTemporaryFile(QDir::tempPath() + QSL("/QupZillaPrintXXXXXX.pdf"));
+                    tempFile->setAutoRemove(false);
+                    if (tempFile->open()) {
+                        qint64 bytesWritten = tempFile->write(data);
+                        tempFile->close();
                         if (bytesWritten == data.size()) {
 #ifdef Q_OS_WIN
                             // This may bring up a PDF viewer window, and even keep it open, but it is the best we can do without adding third-party dependencies.
                             // lpr is not installed by default on Windows, and it also can only print PDF if the printer handles it in hardware.
-                            ShellExecuteW(winId(), L"printto", tempFile.fileName().constData(), ('"' + printerName + '"').constData(), NULL, SW_HIDE);
-                            // TODO: When can we delete the file?
+                            ShellExecuteW(winId(), L"printto", tempFile->fileName().constData(), ('"' + printerName + '"').constData(), NULL, SW_HIDE);
+                            // TODO: When can we delete the actual file (not just the object)?
+                            delete tempFile;
 #else
+                            QProcess *process = new QProcess(this);
+                            connect(process, static_cast<void (QProcess::*)(QProcess::ProcessError)>(&QProcess::error), [=](QProcess::ProcessError) {
+                                tempFile->remove();
+                                tempFile->deleteLater();
+                                process->deleteLater();
+                            });
+                            connect(process, static_cast<void (QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished), [=](int exitCode, QProcess::ExitStatus exitStatus) {
+                                if (exitStatus != QProcess::NormalExit || exitCode != 0) {
+                                    // lpr failed, so delete the temporary file in case it still exists.
+                                    // In case of success, we let lpr delete it, it knows best when it is safe to do so.
+                                    // (lpr queues jobs asynchronously.)
+                                    tempFile->remove();
+                                }
+                                tempFile->deleteLater();
+                                process->deleteLater();
+                            });
                             // -r automatically deletes the file after printing it.
                             // TODO: We should probably pass some additional options such as media size. See, e.g., Okular's fileprinter.cpp.
-                            if (QProcess::execute(QSL("lpr"), QStringList() << QSL("-P") << printerName << QSL("-r") << tempFile.fileName()) != 0) {
-                                // lpr failed, so remove the temporary file in case it still exists.
-                                tempFile.remove();
-                            }
+                            process->start(QSL("lpr"), QStringList() << QSL("-P") << printerName << QSL("-r") << tempFile->fileName());
 #endif
                         } else {
-                            tempFile.remove();
+                            tempFile->remove();
+                            delete tempFile;
                         }
                     }
                 }

--- a/src/lib/app/browserwindow.h
+++ b/src/lib/app/browserwindow.h
@@ -155,6 +155,7 @@ private slots:
     void webSearch();
     void searchOnPage();
     void changeEncoding();
+    void printPage();
 
     void saveSettings();
     void hideNavigationSlot();

--- a/src/lib/app/fileprinter.cpp
+++ b/src/lib/app/fileprinter.cpp
@@ -1,0 +1,406 @@
+/***************************************************************************
+ *   Copyright (C) 2007,2010 by John Layt <john@layt.net>                  *
+ *                                                                         *
+ *   Adaptations for QupZilla                                              *
+ *   Copyright (C) 2016 by Kevin Kofler <kevin.kofler@chello.at>           *
+ *                                                                         *
+ *   FilePrinterPreview based on KPrintPreview (originally LGPL)           *
+ *   Copyright (c) 2007 Alex Merry <huntedhacker@tiscali.co.uk>            *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ ***************************************************************************/
+
+#include "fileprinter.h"
+
+#include <QtPrintSupport/QPrinter>
+#include <QPrintEngine>
+#include <QStringList>
+#include <QSize>
+#include <QtCore/QFile>
+#include <QtCore/QFileInfo>
+#include <QtCore/QProcess>
+#include <QtWidgets/QLabel>
+#include <QtGui/QShowEvent>
+#include <QtNetwork/QTcpSocket>
+#include <QStandardPaths>
+
+using namespace Qz;
+
+void FilePrinter::printFile( QPrinter *printer, const QString &file,
+                             FileDeletePolicy fileDeletePolicy,
+                             PageSelectPolicy pageSelectPolicy, const QString &pageRange )
+{
+    FilePrinter fp;
+    fp.doPrintFile( *printer, file, fileDeletePolicy, pageSelectPolicy, pageRange );
+}
+
+void FilePrinter::doPrintFile( QPrinter &printer, const QString &file, FileDeletePolicy fileDeletePolicy,
+                               PageSelectPolicy pageSelectPolicy, const QString &pageRange )
+{
+
+    if (!QFile::exists(file)) {
+        return;
+    }
+
+    bool doDeleteFile = (fileDeletePolicy == FilePrinter::SystemDeletesFiles);
+
+    if ( printer.printerState() == QPrinter::Aborted || printer.printerState() == QPrinter::Error ) {
+        if ( doDeleteFile ) {
+            QFile::remove( file );
+        }
+        return;
+    }
+
+
+    // Print to a printer via lpr command
+
+    //Decide what executable to use to print with, need the CUPS version of lpr if available
+    //Some distros name the CUPS version of lpr as lpr-cups or lpr.cups so try those first 
+    //before default to lpr, or failing that to lp
+
+    QString exe;
+    if ( !QStandardPaths::findExecutable(QStringLiteral("lpr-cups")).isEmpty() ) {
+        exe = QStringLiteral("lpr-cups");
+    } else if ( !QStandardPaths::findExecutable(QStringLiteral("lpr.cups")).isEmpty() ) {
+        exe = QStringLiteral("lpr.cups");
+    } else if ( !QStandardPaths::findExecutable(QStringLiteral("lpr")).isEmpty() ) {
+        exe = QStringLiteral("lpr");
+    } else if ( !QStandardPaths::findExecutable(QStringLiteral("lp")).isEmpty() ) {
+        exe = QStringLiteral("lp");
+    } else {
+        if ( doDeleteFile ) {
+            QFile::remove( file );
+        }
+        return;
+    }
+
+    bool useCupsOptions = cupsAvailable();
+    QStringList argList = printArguments( printer, fileDeletePolicy, pageSelectPolicy,
+                                          useCupsOptions, pageRange, exe ) << file;
+
+    QProcess *process = new QProcess();
+    QObject::connect(process, static_cast<void (QProcess::*)(QProcess::ProcessError)>(&QProcess::error), [=](QProcess::ProcessError) {
+        if ( doDeleteFile ) {
+            QFile::remove( file );
+        }
+        process->deleteLater();
+    });
+    QObject::connect(process, static_cast<void (QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished), [=](int exitCode, QProcess::ExitStatus exitStatus) {
+        if ( doDeleteFile && (exitStatus != QProcess::NormalExit || exitCode != 0) ) {
+            // lpr failed, so delete the temporary file in case it still exists.
+            // In case of success, we let lpr delete it, it knows best when it is safe to do so.
+            // (lpr queues jobs asynchronously.)
+            QFile::remove( file );
+        }
+        process->deleteLater();
+    });
+    process->start( exe, argList );
+}
+
+bool FilePrinter::cupsAvailable()
+{
+#if defined(Q_OS_OSX)
+    return true;
+#elif defined(Q_OS_UNIX)
+    // Ideally we would have access to the private Qt method
+    // QCUPSSupport::cupsAvailable() to do this as it is very complex routine.
+    // However, if CUPS is available then QPrinter::numCopies() will always return 1
+    // whereas if CUPS is not available it will return the real number of copies.
+    // This behaviour is guaranteed never to change, so we can use it as a reliable substitute.
+    QPrinter testPrinter;
+    testPrinter.setNumCopies( 2 );
+    return ( testPrinter.numCopies() == 1 );
+#else
+    return false;
+#endif
+}
+
+
+
+QStringList FilePrinter::printArguments( QPrinter &printer, FileDeletePolicy fileDeletePolicy,
+                                         PageSelectPolicy pageSelectPolicy, bool useCupsOptions,
+                                         const QString &pageRange, const QString &version )
+{
+    QStringList argList;
+
+    if ( ! destination( printer, version ).isEmpty() ) {
+        argList << destination( printer, version );
+    }
+
+    if ( ! copies( printer, version ).isEmpty() ) {
+        argList << copies( printer, version );
+    }
+
+    if ( ! jobname( printer, version ).isEmpty() ) {
+        argList << jobname( printer, version );
+    }
+
+    if ( ! pages( printer, pageSelectPolicy, pageRange, useCupsOptions, version ).isEmpty() ) {
+        argList << pages( printer, pageSelectPolicy, pageRange, useCupsOptions, version );
+    }
+
+    if ( useCupsOptions && ! cupsOptions( printer ).isEmpty() ) {
+        argList << cupsOptions( printer );
+    }
+
+    if ( ! deleteFile( printer, fileDeletePolicy, version ).isEmpty() ) {
+        argList << deleteFile( printer, fileDeletePolicy, version );
+    }
+
+    if ( version == QLatin1String("lp") ) {
+        argList << QStringLiteral("--");
+    }
+
+    return argList;
+}
+
+QStringList FilePrinter::destination( QPrinter &printer, const QString &version )
+{
+    if ( version == QLatin1String("lp") ) {
+        return QStringList(QStringLiteral("-d")) << printer.printerName();
+    }
+
+    if ( version.startsWith( QLatin1String("lpr") ) ) {
+        return QStringList(QStringLiteral("-P")) << printer.printerName();
+    }
+
+    return QStringList();
+}
+
+QStringList FilePrinter::copies( QPrinter &printer, const QString &version )
+{
+    int cp = printer.actualNumCopies();
+
+    if ( version == QLatin1String("lp") ) {
+        return QStringList(QStringLiteral("-n")) << QStringLiteral("%1").arg( cp );
+    }
+
+    if ( version.startsWith( QLatin1String("lpr") ) ) {
+        return QStringList() << QStringLiteral("-#%1").arg( cp );
+    }
+
+    return QStringList();
+}
+
+QStringList FilePrinter::jobname( QPrinter &printer, const QString &version )
+{
+    if ( ! printer.docName().isEmpty() ) {
+
+        if ( version == QLatin1String("lp") ) {
+            return QStringList(QStringLiteral("-t")) << printer.docName();
+        }
+
+        if ( version.startsWith( QLatin1String("lpr") ) ) {
+            const QString shortenedDocName = QString::fromUtf8(printer.docName().toUtf8().left(255));
+            return QStringList(QStringLiteral("-J")) << shortenedDocName;
+        }
+    }
+
+    return QStringList();
+}
+
+QStringList FilePrinter::deleteFile( QPrinter &, FileDeletePolicy fileDeletePolicy, const QString &version )
+{
+    if ( fileDeletePolicy == FilePrinter::SystemDeletesFiles && version.startsWith( QLatin1String("lpr") ) ) {
+        return QStringList(QStringLiteral("-r"));
+    }
+
+    return QStringList();
+}
+
+QStringList FilePrinter::pages( QPrinter &printer, PageSelectPolicy pageSelectPolicy, const QString &pageRange,
+                                    bool useCupsOptions, const QString &version )
+{
+    if ( pageSelectPolicy == FilePrinter::SystemSelectsPages ) {
+
+        if ( printer.printRange() == QPrinter::Selection && ! pageRange.isEmpty() ) {
+
+            if ( version == QLatin1String("lp") ) {
+                return QStringList(QStringLiteral("-P")) << pageRange ;
+            }
+
+            if ( version.startsWith( QLatin1String("lpr") ) && useCupsOptions ) {
+                return QStringList(QStringLiteral("-o")) << QStringLiteral("page-ranges=%1").arg( pageRange );
+            }
+
+        }
+
+        if ( printer.printRange() == QPrinter::PageRange ) {
+
+            if ( version == QLatin1String("lp") ) {
+                return QStringList(QStringLiteral("-P")) << QStringLiteral("%1-%2").arg( printer.fromPage() )
+                                                            .arg( printer.toPage() );
+            }
+
+            if ( version.startsWith( QLatin1String("lpr") ) && useCupsOptions ) {
+                return QStringList(QStringLiteral("-o")) << QStringLiteral("page-ranges=%1-%2").arg( printer.fromPage() )
+                                                                        .arg( printer.toPage() );
+            }
+
+        }
+
+    }
+
+    return QStringList(); // AllPages
+}
+
+QStringList FilePrinter::cupsOptions( QPrinter &printer )
+{
+    QStringList optionList;
+
+    if ( ! optionMedia( printer ).isEmpty() ) {
+        optionList << optionMedia( printer );
+    }
+
+    if ( ! optionDoubleSidedPrinting( printer ).isEmpty() ) {
+        optionList << optionDoubleSidedPrinting( printer );
+    }
+
+    if ( ! optionPageOrder( printer ).isEmpty() ) {
+        optionList << optionPageOrder( printer );
+    }
+
+    if ( ! optionCollateCopies( printer ).isEmpty() ) {
+        optionList << optionCollateCopies( printer );
+    }
+
+    optionList << optionCupsProperties( printer );
+
+    return optionList;
+}
+
+QStringList FilePrinter::optionMedia( QPrinter &printer )
+{
+    if ( ! mediaPageSize( printer ).isEmpty() && 
+         ! mediaPaperSource( printer ).isEmpty() ) {
+        return QStringList(QStringLiteral("-o")) <<
+                QStringLiteral("media=%1,%2").arg( mediaPageSize( printer ) )
+                                      .arg( mediaPaperSource( printer ) );
+    }
+
+    if ( ! mediaPageSize( printer ).isEmpty() ) {
+        return QStringList(QStringLiteral("-o")) <<
+                QStringLiteral("media=%1").arg( mediaPageSize( printer ) );
+    }
+
+    if ( ! mediaPaperSource( printer ).isEmpty() ) {
+        return QStringList(QStringLiteral("-o")) <<
+                QStringLiteral("media=%1").arg( mediaPaperSource( printer ) );
+    }
+
+    return QStringList();
+}
+
+QString FilePrinter::mediaPageSize( QPrinter &printer )
+{
+    switch ( printer.pageSize() ) {
+    case QPrinter::A0:         return QStringLiteral("A0");
+    case QPrinter::A1:         return QStringLiteral("A1");
+    case QPrinter::A2:         return QStringLiteral("A2");
+    case QPrinter::A3:         return QStringLiteral("A3");
+    case QPrinter::A4:         return QStringLiteral("A4");
+    case QPrinter::A5:         return QStringLiteral("A5");
+    case QPrinter::A6:         return QStringLiteral("A6");
+    case QPrinter::A7:         return QStringLiteral("A7");
+    case QPrinter::A8:         return QStringLiteral("A8");
+    case QPrinter::A9:         return QStringLiteral("A9");
+    case QPrinter::B0:         return QStringLiteral("B0");
+    case QPrinter::B1:         return QStringLiteral("B1");
+    case QPrinter::B10:        return QStringLiteral("B10");
+    case QPrinter::B2:         return QStringLiteral("B2");
+    case QPrinter::B3:         return QStringLiteral("B3");
+    case QPrinter::B4:         return QStringLiteral("B4");
+    case QPrinter::B5:         return QStringLiteral("B5");
+    case QPrinter::B6:         return QStringLiteral("B6");
+    case QPrinter::B7:         return QStringLiteral("B7");
+    case QPrinter::B8:         return QStringLiteral("B8");
+    case QPrinter::B9:         return QStringLiteral("B9");
+    case QPrinter::C5E:        return QStringLiteral("C5");     //Correct Translation?
+    case QPrinter::Comm10E:    return QStringLiteral("Comm10"); //Correct Translation?
+    case QPrinter::DLE:        return QStringLiteral("DL");     //Correct Translation?
+    case QPrinter::Executive:  return QStringLiteral("Executive");
+    case QPrinter::Folio:      return QStringLiteral("Folio");
+    case QPrinter::Ledger:     return QStringLiteral("Ledger");
+    case QPrinter::Legal:      return QStringLiteral("Legal");
+    case QPrinter::Letter:     return QStringLiteral("Letter");
+    case QPrinter::Tabloid:    return QStringLiteral("Tabloid");
+    case QPrinter::Custom:     return QStringLiteral("Custom.%1x%2mm")
+                                            .arg( printer.heightMM() )
+                                            .arg( printer.widthMM() );
+    default:                   return QString();
+    }
+}
+
+// What about Upper and MultiPurpose?  And others in PPD???
+QString FilePrinter::mediaPaperSource( QPrinter &printer )
+{
+    switch ( printer.paperSource() ) {
+    case QPrinter::Auto:            return QString();
+    case QPrinter::Cassette:        return QStringLiteral("Cassette");
+    case QPrinter::Envelope:        return QStringLiteral("Envelope");
+    case QPrinter::EnvelopeManual:  return QStringLiteral("EnvelopeManual");
+    case QPrinter::FormSource:      return QStringLiteral("FormSource");
+    case QPrinter::LargeCapacity:   return QStringLiteral("LargeCapacity");
+    case QPrinter::LargeFormat:     return QStringLiteral("LargeFormat");
+    case QPrinter::Lower:           return QStringLiteral("Lower");
+    case QPrinter::MaxPageSource:   return QStringLiteral("MaxPageSource");
+    case QPrinter::Middle:          return QStringLiteral("Middle");
+    case QPrinter::Manual:          return QStringLiteral("Manual");
+    case QPrinter::OnlyOne:         return QStringLiteral("OnlyOne");
+    case QPrinter::Tractor:         return QStringLiteral("Tractor");
+    case QPrinter::SmallFormat:     return QStringLiteral("SmallFormat");
+    default:                        return QString();
+    }
+}
+
+QStringList FilePrinter::optionDoubleSidedPrinting( QPrinter &printer )
+{
+    switch ( printer.duplex() ) {
+    case QPrinter::DuplexNone:       return QStringList(QStringLiteral("-o")) << QStringLiteral("sides=one-sided");
+    case QPrinter::DuplexAuto:       if ( printer.orientation() == QPrinter::Landscape ) {
+                                         return QStringList(QStringLiteral("-o")) << QStringLiteral("sides=two-sided-short-edge");
+                                     } else {
+                                         return QStringList(QStringLiteral("-o")) << QStringLiteral("sides=two-sided-long-edge");
+                                     }
+    case QPrinter::DuplexLongSide:   return QStringList(QStringLiteral("-o")) << QStringLiteral("sides=two-sided-long-edge");
+    case QPrinter::DuplexShortSide:  return QStringList(QStringLiteral("-o")) << QStringLiteral("sides=two-sided-short-edge");
+    default:                         return QStringList();  //Use printer default
+    }
+}
+
+QStringList FilePrinter::optionPageOrder( QPrinter &printer )
+{
+    if ( printer.pageOrder() == QPrinter::LastPageFirst ) {
+        return QStringList(QStringLiteral("-o")) << QStringLiteral("outputorder=reverse");
+    }
+    return QStringList(QStringLiteral("-o")) << QStringLiteral("outputorder=normal");
+}
+
+QStringList FilePrinter::optionCollateCopies( QPrinter &printer )
+{
+    if ( printer.collateCopies() ) {
+        return QStringList(QStringLiteral("-o")) << QStringLiteral("Collate=True");
+    }
+    return QStringList(QStringLiteral("-o")) << QStringLiteral("Collate=False");
+}
+
+QStringList FilePrinter::optionCupsProperties( QPrinter &printer )
+{
+    QStringList dialogOptions = printer.printEngine()->property(QPrintEngine::PrintEnginePropertyKey(0xfe00)).toStringList();
+    QStringList cupsOptions;
+
+    for ( int i = 0; i < dialogOptions.count(); i = i + 2 ) {
+        if ( dialogOptions[i+1].isEmpty() ) {
+            cupsOptions << QStringLiteral("-o") << dialogOptions[i];
+        } else {
+            cupsOptions << QStringLiteral("-o") << dialogOptions[i] + QLatin1Char('=') + dialogOptions[i+1];
+        }
+    }
+
+    return cupsOptions;
+}
+
+/* kate: replace-tabs on; indent-width 4; */

--- a/src/lib/app/fileprinter.h
+++ b/src/lib/app/fileprinter.h
@@ -1,0 +1,102 @@
+/***************************************************************************
+ *   Copyright (C) 2007, 2010 by John Layt <john@layt.net>                 *
+ *                                                                         *
+ *   Adaptations for QupZilla                                              *
+ *   Copyright (C) 2016 by Kevin Kofler <kevin.kofler@chello.at>           *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ ***************************************************************************/
+
+#ifndef FILEPRINTER_H
+#define FILEPRINTER_H
+
+#include <QtCore/QList>
+#include <QtCore/QString>
+#include <QtPrintSupport/QPrinter>
+
+#include "qzcommon.h"
+
+class QSize;
+
+namespace Qz {
+
+class QUPZILLA_EXPORT FilePrinter
+{
+public:
+
+    /** Whether file(s) get deleted by the application or by the print system.
+     *
+     *  You may need to chose system deletion if your temp file clean-up
+     *  deletes the file before the print system is finished with it.
+     */
+    enum FileDeletePolicy { ApplicationDeletesFiles, SystemDeletesFiles };
+
+    /** Whether pages to be printed are selected by the application or the print system.
+     *
+     *  If application side, then the generated file will only contain those pages
+     *  selected by the user, so FilePrinter will print all the pages in the file.
+     *
+     *  If system side, then the file will contain all the pages in the document, and
+     *  the print system will print the users selected print range from out of the file.
+     *
+     *  Note system side only works in CUPS, not LPR.
+     */
+    enum PageSelectPolicy { ApplicationSelectsPages, SystemSelectsPages };
+
+    /** Print a file using the settings in QPrinter
+     *
+     *  Only supports CUPS and LPR on *NIX.  Page Range only supported in CUPS.
+     *  Most settings unsupported by LPR, some settings unsupported by CUPS.
+     *
+     * @param printer the print settings to use
+     * @param file the file to print
+     * @param fileDeletePolicy if the application or system deletes the file
+     * @param pageSelectPolicy if the application or system selects the pages to print
+     * @param pageRange page range to print if SystemSelectsPages and user chooses Selection in Print Dialog
+     */
+
+    static void printFile( QPrinter *printer, const QString &file,
+                           FileDeletePolicy fileDeletePolicy = FilePrinter::ApplicationDeletesFiles,
+                           PageSelectPolicy pageSelectPolicy = FilePrinter::ApplicationSelectsPages,
+                           const QString &pageRange = QString() );
+
+    /** Return if CUPS Print System is available on this system
+     *
+     * @returns Returns true if CUPS available
+     */
+    static bool cupsAvailable();
+
+protected:
+
+    void doPrintFile( QPrinter &printer, const QString &file,
+                      FileDeletePolicy fileDeletePolicy, PageSelectPolicy pageSelectPolicy,
+                      const QString &pageRange );
+
+    QStringList printArguments( QPrinter &printer,
+                                FileDeletePolicy fileDeletePolicy, PageSelectPolicy pageSelectPolicy,
+                                bool useCupsOptions, const QString &pageRange, const QString &version );
+
+    QStringList destination( QPrinter &printer, const QString &version );
+    QStringList copies( QPrinter &printer, const QString &version );
+    QStringList jobname( QPrinter &printer, const QString &version );
+    QStringList deleteFile( QPrinter &printer, FileDeletePolicy fileDeletePolicy,
+                                   const QString &version );
+    QStringList pages( QPrinter &printer, PageSelectPolicy pageSelectPolicy,
+                              const QString &pageRange, bool useCupsOptions, const QString &version );
+
+    QStringList cupsOptions( QPrinter &printer );
+    QStringList optionMedia( QPrinter &printer );
+    QString mediaPageSize( QPrinter &printer );
+    QString mediaPaperSource( QPrinter &printer );
+    QStringList optionDoubleSidedPrinting( QPrinter &printer );
+    QStringList optionPageOrder( QPrinter &printer );
+    QStringList optionCollateCopies( QPrinter &printer );
+    QStringList optionCupsProperties( QPrinter &printer );
+};
+
+}
+
+#endif // FILEPRINTER_H

--- a/src/lib/app/mainmenu.cpp
+++ b/src/lib/app/mainmenu.cpp
@@ -81,6 +81,9 @@ void MainMenu::initSuperMenu(QMenu* superMenu) const
     superMenu->addAction(m_actions[QSL("File/OpenFile")]);
     superMenu->addSeparator();
     superMenu->addAction(m_actions[QSL("File/SendLink")]);
+#if QT_VERSION >= QT_VERSION_CHECK(5,7,0)
+    superMenu->addAction(m_actions[QSL("File/Print")]);
+#endif
     superMenu->addSeparator();
     superMenu->addAction(m_actions[QSL("Edit/SelectAll")]);
     superMenu->addAction(m_actions[QSL("Edit/Find")]);
@@ -522,7 +525,9 @@ void MainMenu::init()
     ADD_ACTION("File/CloseWindow", m_menuFile, QIcon::fromTheme(QSL("window-close")), tr("Close Window"), SLOT(closeWindow()), "Ctrl+Shift+W");
     m_menuFile->addSeparator();
     ADD_ACTION("File/SendLink", m_menuFile, QIcon::fromTheme(QSL("mail-message-new")), tr("Send Link..."), SLOT(sendLink()), "");
+#if QT_VERSION >= QT_VERSION_CHECK(5,7,0)
     ADD_ACTION("File/Print", m_menuFile, QIcon::fromTheme(QSL("document-print")), tr("&Print..."), SLOT(printPage()), "Ctrl+P");
+#endif
     m_menuFile->addSeparator();
     m_menuFile->addAction(m_actions[QSL("Standard/Quit")]);
 

--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -1,4 +1,4 @@
-QT += webenginecore webenginewidgets webchannel network widgets sql quickwidgets
+QT += webenginecore webenginewidgets webchannel network widgets sql quickwidgets printsupport
 
 TARGET = QupZilla
 TEMPLATE = lib

--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -472,6 +472,9 @@ win32 {
     SOURCES += other/registerqappassociation.cpp
 
     LIBS += -llibeay32
+} else {
+    HEADERS += app/fileprinter.h
+    SOURCES += app/fileprinter.cpp
 }
 
 os2 {


### PR DESCRIPTION
This works by printing to PDF first, then sending the PDF to a printer if printing to a physical printer was requested.

On *nix (including Mac OS X), we use the lpr command, which is typically provided by CUPS nowadays. Currently, no options beyond the printer name are passed, there is room for improvement there. (Okular has a FilePrinter class that handles this in a more sophisticated way.)

On Windows, we use ShellExecuteW with the "printto" verb. In that case, the printer name is unfortunately the only thing that can be passed. The user experience may also be suboptimal depending on the PDF viewer installed on the system. (E.g., Adobe Reader is reported to ignore SW_HIDE.) And if there is no PDF viewer installed at all, it will of course not work at all. But it is the best we can do without bundling something like GhostScript (or requiring the user to install it).

I successfully tested the revision I am now submitting on Fedora Rawhide (actually, I backported the patches to QupZilla 2.0.1 and tested that, but that should not make any difference in practice): it can definitely bring something to paper (and printing to PDF also works), honoring more options is TODO as explained above. I cannot test the Windows code.