### PR TITLE
Added option to delete all cookies on exiting

### DIFF
--- a/src/lib/app/mainapplication.cpp
+++ b/src/lib/app/mainapplication.cpp
@@ -732,11 +732,18 @@ void MainApplication::saveSettings()
     bool deleteHtml5Storage = settings.value("deleteHTML5StorageOnClose", false).toBool();
     settings.endGroup();
 
+    settings.beginGroup("Cookie-Settings");
+    bool deleteCookies = settings.value("clearCookiesOnExit", false).toBool();
+    settings.endGroup();
+
     if (deleteHistory) {
         m_history->clearHistory();
     }
     if (deleteHtml5Storage) {
         ClearPrivateData::clearLocalStorage();
+    }
+    if (deleteCookies) {
+        m_cookieJar->deleteAllCookies();
     }
 
     m_searchEnginesManager->saveSettings();

--- a/src/lib/app/mainapplication.cpp
+++ b/src/lib/app/mainapplication.cpp
@@ -733,7 +733,7 @@ void MainApplication::saveSettings()
     settings.endGroup();
 
     settings.beginGroup("Cookie-Settings");
-    bool deleteCookies = settings.value("clearCookiesOnExit", false).toBool();
+    bool deleteCookies = settings.value("deleteCookiesOnClose", false).toBool();
     settings.endGroup();
 
     if (deleteHistory) {

--- a/src/lib/cookies/cookiemanager.cpp
+++ b/src/lib/cookies/cookiemanager.cpp
@@ -70,6 +70,7 @@ CookieManager::CookieManager()
     ui->saveCookies->setChecked(settings.value("allowCookies", true).toBool());
     ui->filter3rdParty->setChecked(settings.value("filterThirdPartyCookies", false).toBool());
     ui->filterTracking->setChecked(settings.value("filterTrackingCookie", false).toBool());
+    ui->clearOnExit->setChecked(settings.value("clearCookiesOnExit", false).toBool());
     ui->whiteList->addItems(settings.value("whitelist", QStringList()).toStringList());
     ui->blackList->addItems(settings.value("blacklist", QStringList()).toStringList());
     settings.endGroup();
@@ -328,6 +329,7 @@ void CookieManager::closeEvent(QCloseEvent* e)
     settings.setValue("allowCookies", ui->saveCookies->isChecked());
     settings.setValue("filterThirdPartyCookies", ui->filter3rdParty->isChecked());
     settings.setValue("filterTrackingCookie", ui->filterTracking->isChecked());
+    settings.setValue("clearCookiesOnExit", ui->clearOnExit->isChecked());
     settings.setValue("whitelist", whitelist);
     settings.setValue("blacklist", blacklist);
     settings.endGroup();

--- a/src/lib/cookies/cookiemanager.cpp
+++ b/src/lib/cookies/cookiemanager.cpp
@@ -70,7 +70,7 @@ CookieManager::CookieManager()
     ui->saveCookies->setChecked(settings.value("allowCookies", true).toBool());
     ui->filter3rdParty->setChecked(settings.value("filterThirdPartyCookies", false).toBool());
     ui->filterTracking->setChecked(settings.value("filterTrackingCookie", false).toBool());
-    ui->clearOnExit->setChecked(settings.value("clearCookiesOnExit", false).toBool());
+    ui->deleteCookiesOnClose->setChecked(settings.value("deleteCookiesOnClose", false).toBool());
     ui->whiteList->addItems(settings.value("whitelist", QStringList()).toStringList());
     ui->blackList->addItems(settings.value("blacklist", QStringList()).toStringList());
     settings.endGroup();
@@ -329,7 +329,7 @@ void CookieManager::closeEvent(QCloseEvent* e)
     settings.setValue("allowCookies", ui->saveCookies->isChecked());
     settings.setValue("filterThirdPartyCookies", ui->filter3rdParty->isChecked());
     settings.setValue("filterTrackingCookie", ui->filterTracking->isChecked());
-    settings.setValue("clearCookiesOnExit", ui->clearOnExit->isChecked());
+    settings.setValue("deleteCookiesOnClose", ui->deleteCookiesOnClose->isChecked());
     settings.setValue("whitelist", whitelist);
     settings.setValue("blacklist", blacklist);
     settings.endGroup();

--- a/src/lib/cookies/cookiemanager.ui
+++ b/src/lib/cookies/cookiemanager.ui
@@ -427,9 +427,9 @@
         </widget>
        </item>
        <item row="5" column="1" colspan="2">
-        <widget class="QCheckBox" name="clearOnExit">
+        <widget class="QCheckBox" name="deleteCookiesOnClose">
          <property name="text">
-          <string>Remove cookies on exit</string>
+          <string>Delete cookies on close</string>
          </property>
         </widget>
        </item>

--- a/src/lib/cookies/cookiemanager.ui
+++ b/src/lib/cookies/cookiemanager.ui
@@ -426,6 +426,13 @@
          </property>
         </widget>
        </item>
+       <item row="5" column="1" colspan="2">
+        <widget class="QCheckBox" name="clearOnExit">
+         <property name="text">
+          <string>Remove cookies on exit</string>
+         </property>
+        </widget>
+       </item>
        <item row="6" column="3">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
@@ -439,7 +446,7 @@
          </property>
         </spacer>
        </item>
-       <item row="5" column="1" colspan="3">
+       <item row="7" column="1" colspan="3">
         <widget class="QLabel" name="label_19">
          <property name="text">
           <string>&lt;b&gt;Warning:&lt;/b&gt; Filter 3rd party and tracking cookies options can lead to deny some cookies from sites. If you have problems with cookies, try to disable these options first!</string>
@@ -449,7 +456,7 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="3">
+       <item row="9" column="3">
         <widget class="QDialogButtonBox" name="close3">
          <property name="standardButtons">
           <set>QDialogButtonBox::Close</set>


### PR DESCRIPTION
Changes:
Add new option in the cookie manager: "Remove cookies on exit".

Sense:
Gives the user more control over their privacy.

Notes:
New string "Remove cookies on exit" needs to be translated.
German String: "Cookies beim Beenden löschen"
Same feature for the cache would be nice.

Screenshot:
![screenshot-cookiemanager](https://cloud.githubusercontent.com/assets/10425127/22185082/22a74f5c-e0df-11e6-92df-e6aa0566a17e.jpg)
