### PR TITLE
Mac: Copy missing dylib to bundle and document

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -44,13 +44,13 @@ Linux / Unix
 MAC OS X
 ----------------------------------------------------------------------------------
 
-  You need to have Xcode from the Apple App Store installed in Applications, [Command Line Tools for the same Xcode version](https://developer.apple.com/),
+  You need to have Xcode from the Apple App Store installed in Applications, [Command Line Tools for the same Xcode version](https://developer.apple.com/) may be included depending on the version,
   [Homebrew](http://brew.sh/), and `$ brew install openssl` for openssl.
   Next compulsory requirement is Qt 5 (>= 5.7) with QtWebEngine.
-  After successful compilation, you need to run macdeploy.sh script to correctly
-  build the application bundle. You will do it with following command:
+  After successful compilation, you need to set the `QTDIR` environment variable described below and
+  run macdeploy.sh script to correctly build the application bundle. You will do it with following command:
 
-    $ ./mac/macdeploy.sh <path-to-macdeployqt>
+    $ ./mac/macdeploy.sh [<path-to-macdeployqt>]
 
   You need to specify path to macdeployqt (usually in QTDIR/bin/macdeployqt) only
   if it is not in PATH.
@@ -108,6 +108,18 @@ Available Defines
                           Requires linking against libraries from Microsoft Visual C++
                           Compiler 2010
                           (enabled by default)
+
+ OS X specific defines:
+
+     QTDIR                You need to define this environment variable path in order to
+                          deploy an image.
+
+                          Typically with the Qt Online Installer for macOS it is located
+                          in the home directory and is updated/modified with
+                          the MaintenanceTool application.
+
+                          example:
+                          $ export QTDIR="$HOME/Qt/5.7/clang_64"
 
  Linux / Unix specific defines:
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -47,8 +47,8 @@ MAC OS X
   You need to have Xcode from the Apple App Store installed in Applications, [Command Line Tools for the same Xcode version](https://developer.apple.com/) may be included depending on the version,
   [Homebrew](http://brew.sh/), and `$ brew install openssl` for openssl.
   Next compulsory requirement is Qt 5 (>= 5.7) with QtWebEngine.
-  After successful compilation, you need to set the `QTDIR` environment variable described below and
-  run macdeploy.sh script to correctly build the application bundle. You will do it with following command:
+  After successful compilation, you need to build the application bundle and follow any
+  instructions that may be presented. You will do it with following command:
 
     $ ./mac/macdeploy.sh [<path-to-macdeployqt>]
 
@@ -108,18 +108,6 @@ Available Defines
                           Requires linking against libraries from Microsoft Visual C++
                           Compiler 2010
                           (enabled by default)
-
- OS X specific defines:
-
-     QTDIR                You need to define this environment variable path in order to
-                          deploy an image.
-
-                          Typically with the Qt Online Installer for macOS it is located
-                          in the home directory and is updated/modified with
-                          the MaintenanceTool application.
-
-                          example:
-                          $ export QTDIR="$HOME/Qt/5.7/clang_64"
 
  Linux / Unix specific defines:
 

--- a/mac/macdeploy.sh
+++ b/mac/macdeploy.sh
@@ -8,6 +8,7 @@
 MACDEPLOYQT="macdeployqt"
 LIBRARY_NAME="libQupZilla.2.dylib"
 PLUGINS="QupZilla.app/Contents/Resources/plugins"
+QTPLUGINS="QupZilla.app/Contents/PlugIns"
 
 if [ -n "$1" ]; then
  MACDEPLOYQT=$1
@@ -48,7 +49,7 @@ if echo "$answer" | grep -iq "^y"; then
 
     FILE="$QTDIR/plugins/iconengines/libqsvgicon.dylib"
     if [ -f "$FILE" ]; then
-      cp $FILE $PLUGINS
+      cp $FILE $QTPLUGINS
     else
       echo "$FILE: No such file"
       exit 1
@@ -58,7 +59,7 @@ if echo "$answer" | grep -iq "^y"; then
 else
   printf '\nChecking for prior deploy image library plugins at target...\n'
 
-  rm $PLUGINS/libqsvgicon.dylib
+  rm $QTPLUGINS/libqsvgicon.dylib
 fi
 
 # run macdeployqt

--- a/mac/macdeploy.sh
+++ b/mac/macdeploy.sh
@@ -45,7 +45,9 @@ if echo "$answer" | grep -iq "^y"; then
     printf '\nPlease set the environment variable for the Qt platform folder.\n\texample:\n\t$ export QTDIR="$HOME/Qt/5.7/clang_64"\n'
     exit 1
   else
-    printf '\nCopying known, missing, Qt native library plugins to target...\n'
+    printf '\nCopying known, missing, Qt native library plugins to target bundle...\n'
+
+    mkdir -p $QTPLUGINS
 
     FILE="$QTDIR/plugins/iconengines/libqsvgicon.dylib"
     if [ -f "$FILE" ]; then
@@ -57,9 +59,9 @@ if echo "$answer" | grep -iq "^y"; then
 
   fi
 else
-  printf '\nChecking for prior deploy image library plugins at target...\n'
+  printf '\nChecking for prior deploy image Qt native library plugins at target bundle...\n'
 
-  rm $QTPLUGINS/libqsvgicon.dylib
+  rm -Rf $QTPLUGINS
 fi
 
 # run macdeployqt

--- a/mac/macdeploy.sh
+++ b/mac/macdeploy.sh
@@ -55,3 +55,4 @@ $MACDEPLOYQT QupZilla.app
 # create final dmg image
 cd ../mac
 ./create_dmg.sh
+

--- a/mac/macdeploy.sh
+++ b/mac/macdeploy.sh
@@ -51,7 +51,7 @@ if echo "$answer" | grep -iq "^y"; then
 
     FILE="$QTDIR/plugins/iconengines/libqsvgicon.dylib"
     if [ -f "$FILE" ]; then
-      cp $FILE $QTPLUGINS
+      cp $FILE $QTPLUGINS/
     else
       echo "$FILE: No such file"
       exit 1

--- a/mac/macdeploy.sh
+++ b/mac/macdeploy.sh
@@ -19,7 +19,7 @@ cd bin
 # copy libQupZilla into bundle
 cp $LIBRARY_NAME QupZilla.app/Contents/MacOS/
 
-# copy all plugins into bundle
+# copy all QupZilla plugins into bundle
 test -d QupZilla.app/Contents/Resources/plugins || mkdir QupZilla.app/Contents/Resources/plugins
 cp plugins/*.dylib QupZilla.app/Contents/Resources/plugins/
 
@@ -31,6 +31,9 @@ for plugin in QupZilla.app/Contents/Resources/plugins/*.dylib
 do
  install_name_tool -change $LIBRARY_NAME @executable_path/$LIBRARY_NAME $plugin
 done
+
+# copy additional Qt native plugin(s) into bundle
+cp $QTDIR/plugins/iconengines/libqsvgicon.dylib QupZilla.app/Contents/Resources/plugins/
 
 # run macdeployqt
 $MACDEPLOYQT QupZilla.app

--- a/mac/macdeploy.sh
+++ b/mac/macdeploy.sh
@@ -7,6 +7,7 @@
 
 MACDEPLOYQT="macdeployqt"
 LIBRARY_NAME="libQupZilla.2.dylib"
+PLUGINS="QupZilla.app/Contents/Resources/plugins"
 
 if [ -n "$1" ]; then
  MACDEPLOYQT=$1
@@ -20,20 +21,33 @@ cd bin
 cp $LIBRARY_NAME QupZilla.app/Contents/MacOS/
 
 # copy all QupZilla plugins into bundle
-test -d QupZilla.app/Contents/Resources/plugins || mkdir QupZilla.app/Contents/Resources/plugins
-cp plugins/*.dylib QupZilla.app/Contents/Resources/plugins/
+test -d $PLUGINS || mkdir $PLUGINS
+cp plugins/*.dylib $PLUGINS/
 
 # fix libQupZilla
 install_name_tool -change $LIBRARY_NAME @executable_path/$LIBRARY_NAME QupZilla.app/Contents/MacOS/QupZilla
 
 # fix plugins
-for plugin in QupZilla.app/Contents/Resources/plugins/*.dylib
+for plugin in $PLUGINS/*.dylib
 do
  install_name_tool -change $LIBRARY_NAME @executable_path/$LIBRARY_NAME $plugin
 done
 
-# copy additional Qt native plugin(s) into bundle
-cp $QTDIR/plugins/iconengines/libqsvgicon.dylib QupZilla.app/Contents/Resources/plugins/
+# prompt and optionally copy additional Qt native plugin(s) into bundle
+echo -n "Do you wish to redistribute known, missing, Qt plugins (y/n)? "
+old_stty_cfg=$(stty -g)
+stty raw -echo
+answer=$( while ! head -c 1 | grep -i '[yn]'; do true; done )
+stty $old_stty_cfg
+if echo "$answer" | grep -iq "^y"; then
+  printf '\nCopying known, missing, Qt native plugins to target...\n'
+
+  cp $QTDIR/plugins/iconengines/libqsvgicon.dylib $PLUGINS
+else
+  printf '\nChecking for prior deploy image libraries at target...\n'
+
+  rm $PLUGINS/libqsvgicon.dylib
+fi
 
 # run macdeployqt
 $MACDEPLOYQT QupZilla.app
@@ -41,4 +55,3 @@ $MACDEPLOYQT QupZilla.app
 # create final dmg image
 cd ../mac
 ./create_dmg.sh
-

--- a/mac/macdeploy.sh
+++ b/mac/macdeploy.sh
@@ -34,17 +34,29 @@ do
 done
 
 # prompt and optionally copy additional Qt native plugin(s) into bundle
-echo -n "Do you wish to redistribute known, missing, Qt plugins (y/n)? "
+echo -n "Do you wish to redistribute known, missing, Qt Library plugins (y/n)? "
 old_stty_cfg=$(stty -g)
 stty raw -echo
 answer=$( while ! head -c 1 | grep -i '[yn]'; do true; done )
 stty $old_stty_cfg
 if echo "$answer" | grep -iq "^y"; then
-  printf '\nCopying known, missing, Qt native plugins to target...\n'
+  if [ -z ${QTDIR+x} ]; then
+    printf '\nPlease set the environment variable for the Qt platform folder.\n\texample:\n\t$ export QTDIR="$HOME/Qt/5.7/clang_64"\n'
+    exit 1
+  else
+    printf '\nCopying known, missing, Qt native library plugins to target...\n'
 
-  cp $QTDIR/plugins/iconengines/libqsvgicon.dylib $PLUGINS
+    FILE="$QTDIR/plugins/iconengines/libqsvgicon.dylib"
+    if [ -f "$FILE" ]; then
+      cp $FILE $PLUGINS
+    else
+      echo "$FILE: No such file"
+      exit 1
+    fi
+
+  fi
 else
-  printf '\nChecking for prior deploy image libraries at target...\n'
+  printf '\nChecking for prior deploy image library plugins at target...\n'
 
   rm $PLUGINS/libqsvgicon.dylib
 fi
@@ -55,4 +67,3 @@ $MACDEPLOYQT QupZilla.app
 # create final dmg image
 cd ../mac
 ./create_dmg.sh
-


### PR DESCRIPTION
* This fixes the missing svg icons in the menu drop-down. This is a valid issue to be addressed.

NOTE: Be sure to set the `QTDIR` environment variable to point to your platform Qt installation... **EDIT**: ... if you answer `y`es to the prompt at any time is when it is needed.


Applies to #2180 and GH labels should be modified accordingly to accommodate this Qt feature.