### PR TITLE
Fixed new tab not opening on mouse mid button click

### DIFF
--- a/src/lib/webengine/webpage.cpp
+++ b/src/lib/webengine/webpage.cpp
@@ -141,7 +141,7 @@ QVariant WebPage::execJavaScript(const QString &scriptSource, quint32 worldId, i
         }
     });
 
-    loop->exec();
+    loop->exec(QEventLoop::ExcludeUserInputEvents);
     delete loop;
 
     return result;


### PR DESCRIPTION
Whenever the user pressed the middle button the mouse press handler
in WebPage issued an 'execJavaScript' which has its own event loop
causing the mouse release handler to be called before the field
'm_clickedUrl' get the url in the first handler. Since this field
is used to guard the logic in the second handler the new tab wasn't
opening.

Closes #2238