### PR TITLE
CI for Windows and macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
     fi
 
 install:
+  - export QZ_DIR=$PWD
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
          sudo apt-get -qq update;
          sudo apt-get -qq install libssl-dev pkg-config libxcb-util0-dev;
@@ -30,14 +31,21 @@ install:
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
          if [[ "$QT" == "qt58" ]]; then
+              QT_VER=5.8;
+              export QTDIR="$HOME/Qt/$QT_VER/clang_64";
+              echo "Calling brew update...";
               brew update;
               brew outdated openssl || brew upgrade openssl;
-              brew install qt5;
+              QT_INSTALLER_FILE_NAME=qt-opensource-mac-x64-clang-$QT_VER.0;
+              wget "http://download.qt.io/official_releases/qt/$QT_VER/$QT_VER.0/$QT_INSTALLER_FILE_NAME.dmg";
+              hdiutil attach -noverify $QT_INSTALLER_FILE_NAME.dmg;
+              QT_INSTALLER=/Volumes/$QT_INSTALLER_FILE_NAME/$QT_INSTALLER_FILE_NAME.app/Contents/MacOS/$QT_INSTALLER_FILE_NAME;
+              echo "Silently installing Qt...";
+              $QT_INSTALLER --script $QZ_DIR/mac/qt-mac-silent-install.qs;
          fi
     fi
 
 script:
-  - export QZ_DIR=$PWD
   - QMAKE="qmake"
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
          CXXFLAGS="-Wextra -Werror";
@@ -47,9 +55,8 @@ script:
          MACDEPLOYQT="macdeployqt";
          CXXFLAGS="-Wextra -Werror -Wno-inconsistent-missing-override -Wno-deprecated-declarations";
          if [[ "$QT" == "qt58" ]]; then
-              export QTDIR=/usr/local/opt/qt5;
-              MACDEPLOYQT=/usr/local/opt/qt5/bin/macdeployqt;
-              QMAKE=/usr/local/opt/qt5/bin/qmake;
+              MACDEPLOYQT=$QTDIR/bin/macdeployqt;
+              QMAKE=$QTDIR/bin/qmake;
          fi
     fi
   - $QMAKE QMAKE_CXXFLAGS+="$CXXFLAGS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,75 @@ dist: trusty
 language: cpp
 cache: ccache
 
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+
 env:
   - QT=qt58
 
 before_install:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  - export QZ_VER=2.1.99
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+         export DISPLAY=:99.0;
+         sh -e /etc/init.d/xvfb start;
+    fi
 
 install:
-  - sudo apt-get -qq update
-  - sudo apt-get -qq install libssl-dev pkg-config libxcb-util0-dev
-  - if [[ "$QT" == "qt58" ]]; then sudo apt-add-repository -y ppa:beineri/opt-qt58-trusty; sudo apt-get update -qq; sudo apt-get install -qq qt58tools qt58script qt58webengine qt58webchannel qt58declarative qt58x11extras; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+         sudo apt-get -qq update;
+         sudo apt-get -qq install libssl-dev pkg-config libxcb-util0-dev;
+         if [[ "$QT" == "qt58" ]]; then
+              sudo apt-add-repository -y ppa:beineri/opt-qt58-trusty;
+              sudo apt-get update -qq;
+              sudo apt-get install -qq qt58tools qt58script qt58webengine qt58webchannel qt58declarative qt58x11extras;
+         fi
+    fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+         if [[ "$QT" == "qt58" ]]; then
+              brew update;
+              brew outdated openssl || brew upgrade openssl;
+              brew install qt5;
+         fi
+    fi
 
 script:
+  - export QZ_DIR=$PWD
   - QMAKE="qmake"
-  - if [[ "$QT" == "qt58" ]]; then QMAKE="/opt/qt58/bin/qmake"; fi
-  - $QMAKE QMAKE_CXXFLAGS+="-Wextra -Werror"
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+         CXXFLAGS="-Wextra -Werror";
+         if [[ "$QT" == "qt58" ]]; then QMAKE="/opt/qt58/bin/qmake"; fi
+    fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+         MACDEPLOYQT="macdeployqt";
+         CXXFLAGS="-Wextra -Werror -Wno-inconsistent-missing-override -Wno-deprecated-declarations";
+         if [[ "$QT" == "qt58" ]]; then
+              export QTDIR=/usr/local/opt/qt5;
+              MACDEPLOYQT=/usr/local/opt/qt5/bin/macdeployqt;
+              QMAKE=/usr/local/opt/qt5/bin/qmake;
+         fi
+    fi
+  - $QMAKE QMAKE_CXXFLAGS+="$CXXFLAGS"
   - make -j2 || exit 1
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+         cp -v bin/libQupZilla*.dylib tests/autotests;
+    fi
   - cd scripts && ./run_tests.sh $QMAKE
+
+before_deploy:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+         cd $QZ_DIR;
+         ./mac/macdeploy.sh $MACDEPLOYQT;
+         mv bin/QupZilla.dmg bin/QupZilla-${QZ_VER}.dmg;
+    fi
+
+deploy:
+  provider: releases
+  api_key:
+    secure: "bGGHyeMXF3nrFIaJCzA5zicH3TfdcMNY6+DT+84veBoCAsBMIjp+1t//mkEBnyAYZHKV/6XDhgztwinX1yEylvOeXxQXG5J0fYj96UzZmjBY+QmgDc31XgVeKKIbEi0Ab2bkgW3qHyQJ5ao/lZwSPCt1stOnjz0WuGgrjGWoAgEoHBXzRlsGzU2LrF/bXnmjyPL/qe7AaV0neE9mD+FmeQwiBPoP+/cQCyz5veOdjuzCy4I57HLCvNH4y28z1p6qotS+V1jGRj8PgMWWQP/VXVp9glTV0+gGkOLKL91SPKvLkS76f5bgn6K3+vdDASf+ZCNajIsh1YpwiabX4tQKwnCd80Ps9PR5dXcQVPMBRy1lFr6u2ps0ZTTfiBpI6vqyvLtyv2QbrfGZfT5bWtwdqpSRPJhp6b/ieHHduuRkZ0aU3JuTpLeoob+rLlkvYQmpvmDgyTx44/q+UOOetkoSCD276sMxYxsd3DJKyeG320UcQvwU+dR8uv9NDdv9wpUi13mfGqaRdcSXXgUQWpZlzCGvQYwLozcNnFfbtyrY9BlJsH7Sf97b3313qHO1lrz92z4IhagY1eQqyTwUrtdH8VeeWNx3INdnd7/u1bSdTSLerzMOG/xds96XW/kVbB1SO8bG9IEel7kC5oTiEQfWXAvFw54P6F3eRjDCZvXGaZA="
+  file: $QZ_DIR/bin/QupZilla-$QZ_VER.dmg
+  skip_cleanup: true
+  on:
+    tags: true
+    condition: "$TRAVIS_OS_NAME = osx"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,135 @@
+version: 2.1.99.{build}-{branch}
+
+cache:
+  - windows/dependencies
+
+build:
+  parallel: true
+  verbosity: detailed
+
+configuration:
+  - release
+#  - debug
+
+branches:
+  except:
+    - v1.4
+    - v1.6
+    - v1.8
+
+environment:
+  global:
+    QZ_VER: 2.1.99
+    VSVER: 14
+    ARCH: x86
+    QMAKESPEC: win32-msvc2015
+    MAKETOOL: jom
+    TOOLSDIR: C:\Qt\Tools\QtCreator
+
+  matrix:
+    - QTDIR: C:\Qt\5.8\msvc2015
+    - ARCH: x64
+      QTDIR: C:\Qt\5.8\msvc2015_64
+    - PORTABLE_BUILD: "true"
+      QTDIR: C:\Qt\5.8\msvc2015
+
+install:
+  - set QZ_DIR=%CD%
+  - set CPU=32
+  - IF /I "%ARCH%" == "x64" (set CPU=64)
+  - set OPENSSL_DIR="C:\OpenSSL-Win%CPU%"
+  - set ICU_DIR_NAME=icu4c-54_1-Win%CPU%-msvc10
+  - set ICU_DOWNLOAD_URL="http://download.icu-project.org/files/icu4c/54.1/%ICU_DIR_NAME%.zip"
+  - call "C:\Program Files (x86)\Microsoft Visual Studio "%VSVER%".0\VC\vcvarsall.bat" %ARCH%
+  - set PATH=%QTDIR%\bin;%TOOLSDIR%\bin;%OPENSSL_DIR%\bin;%CD%\bin;%PATH%
+
+build_script:
+  - echo "QupZilla BUILD %APPVEYOR_BUILD_VERSION%_%QMAKESPEC%_%CONFIGURATION%_%ARCH%"
+  - qmake -v
+  - qmake CONFIG+=%CONFIGURATION% INCLUDEPATH+="%OPENSSL_DIR%\include" LIBS+=-L%OPENSSL_DIR%\lib QupZilla.pro
+  - call %MAKETOOL%
+
+test_script:
+  - cd %QZ_DIR%\tests\autotests
+  - qmake CONFIG+=%CONFIGURATION% INCLUDEPATH+="%OPENSSL_DIR%\include" LIBS+=-L%OPENSSL_DIR%\lib
+  - call %MAKETOOL%
+  - call %CONFIGURATION%\autotests.exe
+
+after_build:
+  # prepare dependencies
+  - echo [Paths] > %QZ_DIR%\bin\qt.conf && echo Plugins="." >> %QZ_DIR%\bin\qt.conf
+  - copy  %QZ_DIR%\COPYRIGHT %QZ_DIR%\bin\COPYRIGHT.txt
+  - cd %QZ_DIR%\windows
+  - IF NOT EXIST "dependencies" ( mkdir dependencies )
+  - cd dependencies
+  - IF NOT EXIST "%ICU_DIR_NAME%.zip" ( appveyor DownloadFile %ICU_DOWNLOAD_URL% ) else ( echo "Use cached %ICU_DIR_NAME%.zip")
+  # see: https://github.com/appveyor/ci/issues/1347
+  - ps: If (![System.IO.File]::Exists("$env:APPVEYOR_BUILD_FOLDER\windows\dependencies\KillProcDll&FindProcDll.zip")) { (New-Object Net.WebClient).DownloadFile("http://nsis.sourceforge.net/mediawiki/images/5/53/KillProcDll%26FindProcDll.zip", "$env:APPVEYOR_BUILD_FOLDER\windows\dependencies\KillProcDll&FindProcDll.zip") } ELse { echo "Use cached KillProcDll&FindProcDll.zip" }
+  - IF NOT EXIST "Registry.zip" (
+        appveyor DownloadFile "http://nsis.sourceforge.net/mediawiki/images/4/47/Registry.zip" ) else (echo "Use cached Registry.zip")
+  - IF NOT EXIST "AppAssocReg-0.4.zip" (
+        appveyor DownloadFile "http://nsis.sourceforge.net/mediawiki/images/d/d4/AppAssocReg-0.4.zip" ) else (echo "Use cached AppAssocReg-0.4.zip")
+  - IF NOT EXIST "master.tar.gz" (
+        appveyor DownloadFile "http://chromium.googlesource.com/chromium/deps/hunspell_dictionaries/+archive/master.tar.gz" ) else (echo "Use cached master.tar.gz")
+  - mkdir ..\wininstall
+  - cd ..\wininstall
+  - copy ..\*.nsh .\
+  - copy ..\*.ico .\
+  - copy ..\*.bmp .\
+  # prepare nsis plugins
+  - 7z x "..\dependencies\KillProcDll&FindProcDll.zip"
+  - 7z x ..\dependencies\Registry.zip
+  - 7z x ..\dependencies\AppAssocReg-0.4.zip
+  - copy Desktop\Plugin\*.dll .\
+  - copy Plugins\Unicode\*.dll .\
+  # prepare icu
+  - 7z x "..\dependencies\%ICU_DIR_NAME%.zip"
+  # prepare qtwebengine_dictionaries 
+  - mkdir qtwebengine_dictionaries
+  - cd qtwebengine_dictionaries
+  - 7z x ..\..\dependencies\master.tar.gz
+  - 7z x master.tar
+  - mkdir doc
+  - move README* doc\
+  - move COPYING* doc\
+  - cd %QZ_DIR%\windows
+  # set paths
+  - set OPENSSL_BIN_DIR="%OPENSSL_DIR%\bin"
+  - set MSVC_REDIST_DIR="C:\Program Files (x86)\Microsoft Visual Studio "%VSVER%".0\VC\redist\%ARCH%\Microsoft.VC%VSVER%0.CRT"
+  - set ICU_BIN_DIR="%QZ_DIR%\windows\wininstall\icu\bin"
+  - IF /I "%ARCH%" == "x64" (set INSTALLER_VERSION="%QZ_VER% x64" && set ICU_BIN_DIR="%QZ_DIR%\windows\wininstall\icu\bin64") else (set INSTALLER_VERSION="%QZ_VER%")
+  - IF /I "%PORTABLE_BUILD%" == "true" (set INSTALLER_VERSION="%QZ_VER% Portable")
+  - set QTWEBENGINE_DICTIONARIES_DIR="%QZ_DIR%\windows\wininstall\qtwebengine_dictionaries"
+  # make installer
+  - call "C:\Program Files (x86)\NSIS\makensis.exe" /X"Unicode true" /DCUSTOM=1 /DVERSION=%INSTALLER_VERSION% /DARCH=%ARCH% /DMSVC_VER=%VSVER%0 /DOPENSSL_BIN_DIR=%OPENSSL_BIN_DIR% /DMSVC_REDIST_DIR=%MSVC_REDIST_DIR% /DQZ_BIN_DIR=%QZ_DIR%\bin /DICU_BIN_DIR=%ICU_BIN_DIR% /DQT_DIR=%QTDIR% /DQT_BIN_DIR=%QTDIR%\bin /DQT_PLUGINS_DIR=%QTDIR%\plugins /DQTWEBENGINE_DICTIONARIES_DIR=%QTWEBENGINE_DICTIONARIES_DIR% installer.nsi
+
+artifacts:
+   - path: windows\QupZilla*Installer*.exe
+     name: QupZilla Installer (%ARCH%)
+   - path: bin\*.exe
+     name: QupZilla Executable (%ARCH%)
+   - path: bin\*.dll
+     name: QupZilla DLL (%ARCH%)
+
+
+deploy:
+    release: 'Version $(qz_ver)'
+    tag: $(appveyor_repo_tag_name) # don't remove or modify tag field
+    description: 'QupZilla $(qz_ver) Windows Installer Released'
+    provider: GitHub
+    auth_token:
+      secure: BumEo5ic9KIrhc8RxwsKFd/L6WwC0s5LpSef9uH+PtUKICZBZAcyqnPewKUqzEFi  # your encrypted token from GitHub
+    artifact: /QupZilla.*Installer.*\.exe/         # QupZilla Installer
+    draft: false
+    prerelease: false
+    on:
+      appveyor_repo_tag: true                      # deploy on tag push only
+
+# notifications:
+  # - provider: Email
+    # to:
+      # - nowrep@gmail.com
+      # - s.r.alavizadeh@gmail.com
+    # on_build_success: false
+    # on_build_failure: false
+    # on_build_status_changed: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,10 +98,13 @@ after_build:
   - set MSVC_REDIST_DIR="C:\Program Files (x86)\Microsoft Visual Studio "%VSVER%".0\VC\redist\%ARCH%\Microsoft.VC%VSVER%0.CRT"
   - set ICU_BIN_DIR="%QZ_DIR%\windows\wininstall\icu\bin"
   - IF /I "%ARCH%" == "x64" (set INSTALLER_VERSION="%QZ_VER% x64" && set ICU_BIN_DIR="%QZ_DIR%\windows\wininstall\icu\bin64") else (set INSTALLER_VERSION="%QZ_VER%")
-  - IF /I "%PORTABLE_BUILD%" == "true" (set INSTALLER_VERSION="%QZ_VER% Portable")
   - set QTWEBENGINE_DICTIONARIES_DIR="%QZ_DIR%\windows\wininstall\qtwebengine_dictionaries"
   # make installer
-  - call "C:\Program Files (x86)\NSIS\makensis.exe" /X"Unicode true" /DCUSTOM=1 /DVERSION=%INSTALLER_VERSION% /DARCH=%ARCH% /DMSVC_VER=%VSVER%0 /DOPENSSL_BIN_DIR=%OPENSSL_BIN_DIR% /DMSVC_REDIST_DIR=%MSVC_REDIST_DIR% /DQZ_BIN_DIR=%QZ_DIR%\bin /DICU_BIN_DIR=%ICU_BIN_DIR% /DQT_DIR=%QTDIR% /DQT_BIN_DIR=%QTDIR%\bin /DQT_PLUGINS_DIR=%QTDIR%\plugins /DQTWEBENGINE_DICTIONARIES_DIR=%QTWEBENGINE_DICTIONARIES_DIR% installer.nsi
+  - IF /I "%PORTABLE_BUILD%" == "true" (
+        call "C:\Program Files (x86)\NSIS\makensis.exe" /X"Unicode true" /DCUSTOM=1 /DPORTABLE=1 /DVERSION="%QZ_VER% Portable" /DARCH=%ARCH% /DMSVC_VER=%VSVER%0 /DOPENSSL_BIN_DIR=%OPENSSL_BIN_DIR% /DMSVC_REDIST_DIR=%MSVC_REDIST_DIR% /DQZ_BIN_DIR=%QZ_DIR%\bin /DICU_BIN_DIR=%ICU_BIN_DIR% /DQT_DIR=%QTDIR% /DQT_BIN_DIR=%QTDIR%\bin /DQT_PLUGINS_DIR=%QTDIR%\plugins /DQTWEBENGINE_DICTIONARIES_DIR=%QTWEBENGINE_DICTIONARIES_DIR% installer.nsi
+    ) else (
+        call "C:\Program Files (x86)\NSIS\makensis.exe" /X"Unicode true" /DCUSTOM=1 /DVERSION=%INSTALLER_VERSION% /DARCH=%ARCH% /DMSVC_VER=%VSVER%0 /DOPENSSL_BIN_DIR=%OPENSSL_BIN_DIR% /DMSVC_REDIST_DIR=%MSVC_REDIST_DIR% /DQZ_BIN_DIR=%QZ_DIR%\bin /DICU_BIN_DIR=%ICU_BIN_DIR% /DQT_DIR=%QTDIR% /DQT_BIN_DIR=%QTDIR%\bin /DQT_PLUGINS_DIR=%QTDIR%\plugins /DQTWEBENGINE_DICTIONARIES_DIR=%QTWEBENGINE_DICTIONARIES_DIR% installer.nsi
+    )
 
 artifacts:
    - path: windows\QupZilla*Installer*.exe

--- a/mac/macdeploy.sh
+++ b/mac/macdeploy.sh
@@ -34,34 +34,22 @@ do
  install_name_tool -change $LIBRARY_NAME @executable_path/$LIBRARY_NAME $plugin
 done
 
-# prompt and optionally copy additional Qt native plugin(s) into bundle
-echo -n "Do you wish to redistribute known, missing, Qt Library plugins (y/n)? "
-old_stty_cfg=$(stty -g)
-stty raw -echo
-answer=$( while ! head -c 1 | grep -i '[yn]'; do true; done )
-stty $old_stty_cfg
-if echo "$answer" | grep -iq "^y"; then
-  if [ -z ${QTDIR+x} ]; then
-    printf '\nPlease set the environment variable for the Qt platform folder.\n\texample:\n\t$ export QTDIR="$HOME/Qt/5.8/clang_64"\n'
-    exit 1
-  else
-    printf '\nCopying known, missing, Qt native library plugins to target bundle...\n'
-
-    mkdir -p $QTPLUGINS
-
-    FILE="$QTDIR/plugins/iconengines/libqsvgicon.dylib"
-    if [ -f "$FILE" ]; then
-      cp $FILE $QTPLUGINS/
-    else
-      echo "$FILE: No such file"
-      exit 1
-    fi
-
-  fi
+if [ -z ${QTDIR+x} ]; then
+  printf '\nPlease set the environment variable for the Qt platform folder.\n\texample:\n\t$ export QTDIR="$HOME/Qt/5.8/clang_64"\n'
+  exit 1
 else
-  printf '\nChecking for prior deploy image Qt native library plugins at target bundle...\n'
+  printf '\nCopying known, missing, Qt native library plugins to target bundle...\n'
 
-  rm -Rf $QTPLUGINS
+  mkdir -p $QTPLUGINS
+
+  FILE="$QTDIR/plugins/iconengines/libqsvgicon.dylib"
+  if [ -f "$FILE" ]; then
+    cp $FILE $QTPLUGINS/
+  else
+    echo "$FILE: No such file"
+    exit 1
+  fi
+
 fi
 
 # run macdeployqt

--- a/mac/qt-mac-silent-install.qs
+++ b/mac/qt-mac-silent-install.qs
@@ -1,0 +1,55 @@
+function Controller() {
+    installer.autoRejectMessageBoxes();
+    installer.installationFinished.connect(function() {
+        gui.clickButton(buttons.NextButton);
+    })
+}
+
+Controller.prototype.WelcomePageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.CredentialsPageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.IntroductionPageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.TargetDirectoryPageCallback = function() {
+    gui.currentPageWidget().TargetDirectoryLineEdit.setText(installer.value("HomeDir") + "/Qt");
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.ComponentSelectionPageCallback = function() {
+    var widget = gui.currentPageWidget();
+
+    widget.deselectAll();
+    widget.selectComponent("qt.58.clang_64");
+    widget.selectComponent("qt.58.qtwebengine");
+    widget.selectComponent("qt.58.qtscript");
+
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.LicenseAgreementPageCallback = function() {
+    gui.currentPageWidget().AcceptLicenseRadioButton.setChecked(true);
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.StartMenuDirectoryPageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.ReadyForInstallationPageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.FinishedPageCallback = function() {
+    var checkBoxForm = gui.currentPageWidget().LaunchQtCreatorCheckBoxForm
+    if (checkBoxForm && checkBoxForm.launchQtCreatorCheckBox) {
+        checkBoxForm.launchQtCreatorCheckBox.checked = false;
+    }
+    gui.clickButton(buttons.FinishButton);
+}

--- a/tests/autotests/autotests.pro
+++ b/tests/autotests/autotests.pro
@@ -4,6 +4,8 @@ QT += webenginewidgets network widgets printsupport sql script dbus testlib
 
 TARGET = autotests
 
+CONFIG -= app_bundle
+
 !unix|mac: LIBS += -L$$PWD/../../bin -lQupZilla
 !mac:unix: LIBS += $$PWD/../../bin/libQupZilla.so
 
@@ -19,6 +21,15 @@ exists($$PWD/../../bin/plugins/libKWalletPasswords.so) {
 exists($$PWD/../../bin/plugins/libGnomeKeyringPasswords.so) {
     LIBS += $$PWD/../../bin/plugins/libGnomeKeyringPasswords.so
     DEFINES += HAVE_GNOME_PASSWORDS_PLUGIN
+}
+
+mac {
+    # homebrew openssl
+    BREW_OPENSSL = $$system("brew --prefix openssl")
+    INCLUDEPATH += $$BREW_OPENSSL/include
+    LIBS += -L$$BREW_OPENSSL/lib
+
+    LIBS += -lcrypto -framework CoreServices
 }
 
 DESTDIR =

--- a/windows/installer.nsi
+++ b/windows/installer.nsi
@@ -1,6 +1,6 @@
 ﻿; QupZilla Windows Installer NSIS Script
-; Copyright (C) 2010-2014  David Rosca <nowrep@gmail.com>
-;               2012-2013  S. Razi Alavizadeh <s.r.alavizadeh@gmail.com>
+; Copyright (C) 2010-2017  David Rosca <nowrep@gmail.com>
+;               2012-2017  S. Razi Alavizadeh <s.r.alavizadeh@gmail.com>
 ;
 ; For compiling this script you need following plugins:
 ; FindProcDLL_plug-in, KillProcDLL_plug-in and 'AllAssociation.nsh' needs
@@ -16,15 +16,30 @@ RequestExecutionLevel admin
 ; if ___WINVER__NSH___ is defined to determine if RequestExecutionLevel is
 ; available.
 !include /NONFATAL WinVer.nsh
+!include x64.nsh
 
 !addplugindir "wininstall\"
+
+!ifndef CUSTOM
+  !define VERSION 2.1.2
+  !define ARCH x86
+  !define MSVC_VER 140
+  !define OPENSSL_BIN_DIR .
+  !define MSVC_REDIST_DIR .
+  !define QZ_BIN_DIR .
+  !define ICU_BIN_DIR .
+  !define QT_DIR .
+  !define QT_BIN_DIR .
+  !define QT_PLUGINS_DIR .
+  !define QTWEBENGINE_DICTIONARIES_DIR qtwebengine_dictionaries
+!endif
 
 !include "FileFunc.nsh"
 !include "wininstall\AllAssociation.nsh"
 SetCompressor /SOLID /FINAL lzma
 
 !define PRODUCT_NAME "QupZilla"
-!define /date PRODUCT_VERSION "2.1.2"
+!define /date PRODUCT_VERSION "${VERSION}"
 !define PRODUCT_DIR_REGKEY "Software\Microsoft\Windows\CurrentVersion\App Paths\qupzilla.exe"
 !define PRODUCT_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"
 !define PRODUCT_UNINST_ROOT_KEY "HKLM"
@@ -38,7 +53,7 @@ SetCompressor /SOLID /FINAL lzma
 !define MUI_UNWELCOMEFINISHPAGE_BITMAP "wininstall\welcome.bmp"
 
 !insertmacro MUI_PAGE_WELCOME
-!insertmacro MUI_PAGE_LICENSE COPYRIGHT.txt
+!insertmacro MUI_PAGE_LICENSE ${QZ_BIN_DIR}\COPYRIGHT.txt
 !insertmacro MUI_PAGE_COMPONENTS
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_INSTFILES
@@ -105,73 +120,72 @@ notRunning:
   SetOverwrite on
 
   SetOutPath "$INSTDIR"
-  File "COPYRIGHT.txt"
-  File "qupzilla.exe"
-  File "qupzilla.dll"
-  File "libeay32.dll"
-  File "ssleay32.dll"
-  File "qt.conf"
-  File "concrt140.dll"
-  File "msvcp140.dll"
-  File "vccorlib140.dll"
-  File "vcruntime140.dll"
-  File "icudt54.dll"
-  File "icuin54.dll"
-  File "icuuc54.dll"
-  File "libEGL.dll"
-  File "libGLESv2.dll"
-  File "opengl32sw.dll"
-  File "D3Dcompiler_47.dll"
-  File "Qt5Core.dll"
-  File "Qt5Gui.dll"
-  File "Qt5Network.dll"
-  File "Qt5Positioning.dll"
-  File "Qt5PrintSupport.dll"
-  File "Qt5Qml.dll"
-  File "Qt5Quick.dll"
-  File "Qt5QuickWidgets.dll"
-  File "Qt5Sql.dll"
-  File "Qt5Svg.dll"
-  File "Qt5WinExtras.dll"
-  File "Qt5WebEngine.dll"
-  File "Qt5WebEngineCore.dll"
-  File "Qt5WebEngineWidgets.dll"
-  File "Qt5WebChannel.dll"
-  File "Qt5Widgets.dll"
-  File "QtWebEngineProcess.exe"
+  File "${QZ_BIN_DIR}\COPYRIGHT.txt"
+  File "${QZ_BIN_DIR}\qupzilla.exe"
+  File "${QZ_BIN_DIR}\qupzilla.dll"
+  File "${QZ_BIN_DIR}\qt.conf"
+  File "${OPENSSL_BIN_DIR}\libeay32.dll"
+  File "${OPENSSL_BIN_DIR}\ssleay32.dll"
+  File "${MSVC_REDIST_DIR}\*"
+  File "${ICU_BIN_DIR}\icudt54.dll"
+  File "${ICU_BIN_DIR}\icuin54.dll"
+  File "${ICU_BIN_DIR}\icuuc54.dll"
+  File "${QT_BIN_DIR}\libEGL.dll"
+  File "${QT_BIN_DIR}\libGLESv2.dll"
+  File "${QT_BIN_DIR}\opengl32sw.dll"
+  File "${QT_BIN_DIR}\D3Dcompiler_47.dll"
+  File "${QT_BIN_DIR}\Qt5Core.dll"
+  File "${QT_BIN_DIR}\Qt5Gui.dll"
+  File "${QT_BIN_DIR}\Qt5Network.dll"
+  File "${QT_BIN_DIR}\Qt5Positioning.dll"
+  File "${QT_BIN_DIR}\Qt5PrintSupport.dll"
+  File "${QT_BIN_DIR}\Qt5Qml.dll"
+  File "${QT_BIN_DIR}\Qt5Quick.dll"
+  File "${QT_BIN_DIR}\Qt5QuickWidgets.dll"
+  File "${QT_BIN_DIR}\Qt5Sql.dll"
+  File "${QT_BIN_DIR}\Qt5Svg.dll"
+  File "${QT_BIN_DIR}\Qt5WinExtras.dll"
+  File "${QT_BIN_DIR}\Qt5WebEngine.dll"
+  File "${QT_BIN_DIR}\Qt5WebEngineCore.dll"
+  File "${QT_BIN_DIR}\Qt5WebEngineWidgets.dll"
+  File "${QT_BIN_DIR}\Qt5WebChannel.dll"
+  File "${QT_BIN_DIR}\Qt5Widgets.dll"
+  File "${QT_BIN_DIR}\QtWebEngineProcess.exe"
 
   SetOutPath "$INSTDIR\iconengines"
-  File "iconengines\qsvgicon.dll"
+  File "${QT_PLUGINS_DIR}\iconengines\qsvgicon.dll"
 
   SetOutPath "$INSTDIR\imageformats"
-  File "imageformats\*.dll"
+  File "${QT_PLUGINS_DIR}\imageformats\*.dll"
 
   SetOutPath "$INSTDIR\platforms"
-  File "platforms\qwindows.dll"
+  File "${QT_PLUGINS_DIR}\platforms\qwindows.dll"
 
   SetOutPath "$INSTDIR\printsupport"
-  File "printsupport\windowsprintersupport.dll"
+  File "${QT_PLUGINS_DIR}\printsupport\windowsprintersupport.dll"
 
   SetOutPath "$INSTDIR\qml\QtQuick.2"
-  File "qml\QtQuick.2\*"
+  File "${QT_DIR}\qml\QtQuick.2\*"
 
   SetOutPath "$INSTDIR\qml\QtWebEngine"
-  File "qml\QtWebEngine\*"
+  File "${QT_DIR}\qml\QtWebEngine\*"
 
   SetOutPath "$INSTDIR\resources"
-  File "resources\*"
+  File "${QT_DIR}\resources\*"
 
   SetOutPath "$INSTDIR\sqldrivers"
-  File "sqldrivers\qsqlite.dll"
+  File "${QT_PLUGINS_DIR}\sqldrivers\qsqlite.dll"
 
   SetOutPath "$INSTDIR\translations\qtwebengine_locales"
-  File "translations\qtwebengine_locales\*"
+  File "${QT_DIR}\translations\qtwebengine_locales\*"
 
   SetOutPath "$INSTDIR\qtwebengine_dictionaries\doc"
-  File "qtwebengine_dictionaries\doc\README-en-US.txt"
+  ; In some packages underline '_' is used and in some other packages dash '-' is used so we use wildcard
+  File "${QTWEBENGINE_DICTIONARIES_DIR}\doc\README*en*US.txt"
 
   SetOutPath "$INSTDIR\qtwebengine_dictionaries"
-  File "qtwebengine_dictionaries\en_US.bdic"
+  ; in some packages *.bdic files use dash '-' instead of underline '_' followed by a version number. e.g. en-US-3-0.bdic
+  File "${QTWEBENGINE_DICTIONARIES_DIR}\en*US*.bdic"
 
   call RegisterCapabilities
 SectionEnd
@@ -181,45 +195,45 @@ SectionGroup $(TITLE_SecThemes) SecThemes
   Section Default SecDefault
   SectionIn RO
   SetOutPath "$INSTDIR\themes\windows"
-  File "themes\windows\*"
+  File "${QZ_BIN_DIR}\themes\windows\*"
   SetOutPath "$INSTDIR\themes\windows\images"
-  File "themes\windows\images\*"
+  File "${QZ_BIN_DIR}\themes\windows\images\*"
   SectionEnd
 
   Section Chrome SecChrome
   SetOutPath "$INSTDIR\themes\chrome"
-  File "themes\chrome\*"
+  File "${QZ_BIN_DIR}\themes\chrome\*"
   SetOutPath "$INSTDIR\themes\chrome\images"
-  File "themes\chrome\images\*"
+  File "${QZ_BIN_DIR}\themes\chrome\images\*"
   SectionEnd
 
   Section Mac SecMac
   SetOutPath "$INSTDIR\themes\mac"
-  File "themes\mac\*"
+  File "${QZ_BIN_DIR}\themes\mac\*"
   SetOutPath "$INSTDIR\themes\mac\images"
-  File "themes\mac\images\*"
+  File "${QZ_BIN_DIR}\themes\mac\images\*"
   SectionEnd
 
   Section Breathe SecBreathe
   SetOutPath "$INSTDIR\themes\breathe"
-  File "themes\breathe\*"
+  File "${QZ_BIN_DIR}\themes\breathe\*"
   SetOutPath "$INSTDIR\themes\breathe\images"
-  File "themes\breathe\images\*"
+  File "${QZ_BIN_DIR}\themes\breathe\images\*"
   SectionEnd
 SectionGroupEnd
 
 Section $(TITLE_SecTranslations) SecTranslations
   SetOutPath "$INSTDIR\locale"
-  File "locale\*.qm"
+  File "${QZ_BIN_DIR}\locale\*.qm"
   SetOutPath "$INSTDIR\qtwebengine_dictionaries\doc"
-  File "qtwebengine_dictionaries\doc\*"
+  File "${QTWEBENGINE_DICTIONARIES_DIR}\doc\*"
   SetOutPath "$INSTDIR\qtwebengine_dictionaries"
-  File "qtwebengine_dictionaries\*.bdic"
+  File "${QTWEBENGINE_DICTIONARIES_DIR}\*.bdic"
 SectionEnd
 
 Section $(TITLE_SecPlugins) SecPlugins
   SetOutPath "$INSTDIR\plugins"
-  File "plugins\*.dll"
+  File "${QZ_BIN_DIR}\plugins\*.dll"
 SectionEnd
 
 SectionGroup $(TITLE_SecSetASDefault) SecSetASDefault
@@ -313,6 +327,22 @@ SectionEnd
 BrandingText "${PRODUCT_NAME} ${PRODUCT_VERSION} Installer"
 
 Function .onInit
+        ;Prevent running installer of 64-bit QupZilla on 32-bit Windows
+        ${If} ${RunningX64}
+          ${If} ${ARCH} == "x64"
+            StrCpy $InstDir "$PROGRAMFILES64\${PRODUCT_NAME}\"
+          ${Else}
+            StrCpy $InstDir "$PROGRAMFILES32\${PRODUCT_NAME}\"
+          ${Endif}
+        ${Else}
+          ${If} ${ARCH} == "x64"
+            MessageBox MB_OK|MB_ICONEXCLAMATION "This installation requiers Windows x64!"
+            Quit
+          ${Else}
+            StrCpy $InstDir "$PROGRAMFILES\${PRODUCT_NAME}\"
+          ${Endif}
+        ${EndIf}
+
         ;Prevent Multiple Instances
         System::Call 'kernel32::CreateMutexA(i 0, i 0, t "QupZillaInstaller-4ECB4694-2C39-4f93-9122-A986344C4E7B") i .r1 ?e'
         Pop $R0

--- a/windows/installer.nsi
+++ b/windows/installer.nsi
@@ -206,14 +206,6 @@ SectionGroup $(TITLE_SecThemes) SecThemes
   SetOutPath "$INSTDIR\themes\breathe\images"
   File "themes\breathe\images\*"
   SectionEnd
-
-  Section Old SecOld
-  SetOutPath "$INSTDIR\themes\default"
-  File "themes\default\*"
-  SetOutPath "$INSTDIR\themes\default\images"
-  File "themes\default\images\*"
-  SectionEnd
-
 SectionGroupEnd
 
 Section $(TITLE_SecTranslations) SecTranslations


### PR DESCRIPTION
This patch add OSX build/deploy using Travis and also add integration for AppVeyor to support build/deploy under Windows. It will deploy on new tags (macOS DMG file, x86/x64 installers and installer for portable version).

To test deployed binaries [see](https://github.com/srazi/qupzilla/releases/tag/test_deploy_win_osx) (I have not tested DMG file)
 
Before merging you have to replace github api token by your tokens or disable deploy part.

**Windows Portable Installer:**
It is an installer that doesn't need admin rights to run and won't write to registry and also won't create an uninstaller..