### PR TITLE
TravisCI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 dist: trusty
 language: cpp
-cache: apt
+cache: ccache
 
 env:
   - QT=qt58

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ script:
   - QMAKE="qmake"
   - if [[ "$QT" == "qt58" ]]; then QMAKE="/opt/qt58/bin/qmake"; fi
   - $QMAKE QMAKE_CXXFLAGS+="-Wextra -Werror"
-  - make || exit 1
+  - make -j2 || exit 1
   - cd scripts && ./run_tests.sh $QMAKE


### PR DESCRIPTION
* Not sure why it was "apt" before, now it utilize ccache correctly.
  The build time is cut down from 13 min to 4 min.
  This is the build with cache already generated: https://travis-ci.org/Chocobo1/qupzilla/builds/211687481
* Use 2 make jobs, TravisCI allocates 2 cpus per build: https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments