### PR TITLE
Unix: Allow git hooks to work for development on all related nixes including Mac

### DIFF
--- a/src/defines.pri
+++ b/src/defines.pri
@@ -47,13 +47,7 @@ win32-msvc* {
 }
 
 # QtDBus not available on Mac
-mac {
-    DEFINES *= DISABLE_DBUS
-
-    # Git revision
-    rev = $$system(cd ../ && sh $$PWD/../scripts/getrevision.sh)
-    !equals(rev, ""): DEFINES *= GIT_REVISION=\\\"""$$rev"\\\""
-}
+mac: DEFINES *= DISABLE_DBUS
 
 haiku-* {
     DEFINES *= DISABLE_DBUS
@@ -89,12 +83,14 @@ haiku-* {
     DEFINES *= USE_LIBPATH=\\\"""$$library_folder"\\\""
     DEFINES *= USE_DATADIR=\\\"""$$data_folder"\\\""
 
+    # Define QZ_WS_X11 even with Qt5 (but only when building for X11)
+    !contains(DEFINES, NO_X11) DEFINES *= QZ_WS_X11
+}
+
+unix: {
     # Git revision
     rev = $$system(cd ../ && sh $$PWD/../scripts/getrevision.sh)
     !equals(rev, ""): DEFINES *= GIT_REVISION=\\\"""$$rev"\\\""
-
-    # Define QZ_WS_X11 even with Qt5 (but only when building for X11)
-    !contains(DEFINES, NO_X11) DEFINES *= QZ_WS_X11
 }
 
 isEmpty(QMAKE_LRELEASE) {

--- a/src/defines.pri
+++ b/src/defines.pri
@@ -47,7 +47,13 @@ win32-msvc* {
 }
 
 # QtDBus not available on Mac
-mac: DEFINES *= DISABLE_DBUS
+mac {
+    DEFINES *= DISABLE_DBUS
+
+    # Git revision
+    rev = $$system(cd ../ && sh $$PWD/../scripts/getrevision.sh)
+    !equals(rev, ""): DEFINES *= GIT_REVISION=\\\"""$$rev"\\\""
+}
 
 haiku-* {
     DEFINES *= DISABLE_DBUS


### PR DESCRIPTION
* Same feature already optional in Linux via https://github.com/QupZilla/qupzilla/blob/a71302fbc6f91aaf75ac8afca7f62227ea5ef767/git_hooks/hooks-install.sh
* Windows should probably have this too for developers but don't have MSVS installed to test and won't for quite some time.

Post followup for #1958

---
**NOTE**: PR'd to `master` so I presume it won't show up until 2.2.0

<img src="https://cloud.githubusercontent.com/assets/114709/24093413/501911da-0d19-11e7-89d4-8894c5dc29de.png" alt="About with hash" title="Click to enlarge" width="160" height="80" />

@srazi
Please take a look at this image and look at the speed dial on the Mac. It's been this way for a really long time although the broken-image image changed. I have nothing special proxy wise e.g. direct TCP/IP and clean profile. Linkage works but just no images on the Mac like there is Linux and Windows. Thanks.
