### PR TITLE
Open URLs from "Go to web address" (contextmenu) in a new tab

### DIFF
--- a/src/lib/webengine/webview.cpp
+++ b/src/lib/webengine/webview.cpp
@@ -522,7 +522,7 @@ void WebView::openUrlInNewTab(const QUrl &url, Qz::NewTabPositionFlags position)
 void WebView::openActionUrl()
 {
     if (QAction* action = qobject_cast<QAction*>(sender())) {
-        load(action->data().toUrl());
+        openUrlInNewTab(action->data().toUrl(), Qz::NT_SelectedTab);
     }
 }
 


### PR DESCRIPTION
Problem:
The actions from the context menu: "Translate page", "Validate page", "Search ... with Google" and "Show source code" opens the action page in a new selected tab. "Go to web address" instead, opens the selected URL in the same tab. For the users, that want to read the rest of the origin page is it better, when the new page opens in a new tab.

Changes:
The "Go to web address" action opens the selected text link in a new selected tab.