### PR TITLE
Mac: Version bump Travis CI OS X version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: ccache
 matrix:
   include:
     - os: osx
-      osx_image: xcode8.2
+      osx_image: xcode8.3
 
 env:
   - QT=qt58


### PR DESCRIPTION
* Current release is OS X 10.12.4 *(Sierra)* with Xcode 8.3 *(8E162)*
* Successful make, bundle, and open with 930f1921adb9af41f77cfbac1e15184e8d49ba74 and Qt 5.8 Unified Installer installation.

Ref:
* https://docs.travis-ci.com/user/osx-ci-environment/#os-x-version