### PR TITLE
Session manager

### DIFF
--- a/src/lib/app/browserwindow.cpp
+++ b/src/lib/app/browserwindow.cpp
@@ -164,6 +164,7 @@ void BrowserWindow::postLaunch()
 
     case MainApplication::OpenHomePage:
     case MainApplication::RestoreSession:
+    case MainApplication::SelectSession:
         startUrl = m_homepage;
         break;
 
@@ -178,7 +179,7 @@ void BrowserWindow::postLaunch()
             startUrl.clear();
             m_tabWidget->addView(QUrl("qupzilla:restore"), Qz::NT_CleanSelectedTabAtTheEnd);
         }
-        else if (mApp->afterLaunch() == MainApplication::RestoreSession && mApp->restoreManager()) {
+        else if ((mApp->afterLaunch() == MainApplication::SelectSession || mApp->afterLaunch() == MainApplication::RestoreSession) && mApp->restoreManager()) {
             addTab = !mApp->restoreSession(this, mApp->restoreManager()->restoreData());
         }
         break;
@@ -1316,7 +1317,7 @@ void BrowserWindow::closeEvent(QCloseEvent* event)
     Settings settings;
     bool askOnClose = settings.value("Browser-Tabs-Settings/AskOnClosing", true).toBool();
 
-    if (mApp->afterLaunch() == MainApplication::RestoreSession && mApp->windowCount() == 1) {
+    if ((mApp->afterLaunch() == MainApplication::SelectSession || mApp->afterLaunch() == MainApplication::RestoreSession) && mApp->windowCount() == 1) {
         askOnClose = false;
     }
 

--- a/src/lib/app/datapaths.cpp
+++ b/src/lib/app/datapaths.cpp
@@ -148,5 +148,10 @@ void DataPaths::initCurrentProfile(const QString &profilePath)
     if (m_paths[Cache].isEmpty())
         m_paths[Cache].append(m_paths[CurrentProfile].at(0) + QLatin1String("/cache"));
 
-    QDir().mkpath(m_paths[Cache].at(0));
+    if (m_paths[Sessions].isEmpty())
+        m_paths[Sessions].append(m_paths[CurrentProfile].at(0) + QLatin1String("/sessions"));
+
+    QDir dir;
+    dir.mkpath(m_paths[Cache].at(0));
+    dir.mkpath(m_paths[Sessions].at(0));
 }

--- a/src/lib/app/datapaths.h
+++ b/src/lib/app/datapaths.h
@@ -35,7 +35,8 @@ public:
         CurrentProfile = 6,      // $Profiles/current_profile
         Temp = 7,                // $Config/tmp
         Cache = 8,               // $XDG_CACHE_HOME/qupzilla or $CurrentProfile/cache
-        LastPath = 9
+        Sessions = 9,            // $CurrentProfile/sessions
+        LastPath = 10
     };
 
     explicit DataPaths();

--- a/src/lib/app/mainapplication.cpp
+++ b/src/lib/app/mainapplication.cpp
@@ -314,7 +314,7 @@ MainApplication::MainApplication(int &argc, char** argv)
         sessionManager()->backupSavedSessions();
 
         if (m_isStartingAfterCrash || afterLaunch() == RestoreSession) {
-            m_restoreManager = new RestoreManager();
+            m_restoreManager = new RestoreManager(sessionManager()->lastActiveSessionPath());
             if (!m_restoreManager->isValid()) {
                 destroyRestoreManager();
             } else {
@@ -785,6 +785,8 @@ void MainApplication::saveSettings()
     qzSettings->saveSettings();
     AdBlockManager::instance()->save();
     QFile::remove(DataPaths::currentProfilePath() + QLatin1String("/WebpageIcons.db"));
+
+    sessionManager()->saveSettings();
 }
 
 void MainApplication::messageReceived(const QString &message)

--- a/src/lib/app/mainapplication.cpp
+++ b/src/lib/app/mainapplication.cpp
@@ -281,6 +281,14 @@ MainApplication::MainApplication(int &argc, char** argv)
         m_sessionManager = new SessionManager(this);
         m_autoSaver = new AutoSaver(this);
         connect(m_autoSaver, SIGNAL(save()), m_sessionManager, SLOT(autoSaveLastSession()));
+
+        Settings settings;
+        m_isStartingAfterCrash = settings.value("SessionRestore/isRunning", false).toBool();
+        settings.setValue("SessionRestore/isRunning", true);
+
+        // we have to ask about startup session before creating main window
+        if (!m_isStartingAfterCrash && afterLaunch() == SelectSession)
+            m_restoreManager = new RestoreManager(sessionManager()->askSessionFromUser());
     }
 
     translateApp();
@@ -299,11 +307,8 @@ MainApplication::MainApplication(int &argc, char** argv)
 
 
     if (!isPrivate()) {
-        Settings settings;
-        m_isStartingAfterCrash = settings.value("SessionRestore/isRunning", false).toBool();
-        settings.setValue("SessionRestore/isRunning", true);
-
 #ifndef DISABLE_CHECK_UPDATES
+        Settings settings;
         bool checkUpdates = settings.value("Web-Browser-Settings/CheckUpdates", true).toBool();
 
         if (checkUpdates) {

--- a/src/lib/app/mainapplication.cpp
+++ b/src/lib/app/mainapplication.cpp
@@ -46,6 +46,7 @@
 #include "desktopnotificationsfactory.h"
 #include "html5permissions/html5permissionsmanager.h"
 #include "scripts.h"
+#include "sessionmanager.h"
 
 #include <QWebEngineSettings>
 #include <QDesktopServices>
@@ -91,6 +92,7 @@ MainApplication::MainApplication(int &argc, char** argv)
     , m_browsingLibrary(0)
     , m_networkManager(0)
     , m_restoreManager(0)
+    , m_sessionManager(0)
     , m_downloadManager(0)
     , m_userAgentManager(0)
     , m_searchEnginesManager(0)
@@ -277,6 +279,10 @@ MainApplication::MainApplication(int &argc, char** argv)
 
     m_autoSaver = new AutoSaver(this);
     connect(m_autoSaver, SIGNAL(save()), this, SLOT(saveSession()));
+
+    if (!isPrivate()) {
+        m_sessionManager = new SessionManager(this);
+    }
 
     translateApp();
     loadSettings();
@@ -560,6 +566,11 @@ NetworkManager *MainApplication::networkManager()
 RestoreManager* MainApplication::restoreManager()
 {
     return m_restoreManager;
+}
+
+SessionManager* MainApplication::sessionManager()
+{
+    return m_sessionManager;
 }
 
 DownloadManager* MainApplication::downloadManager()

--- a/src/lib/app/mainapplication.h
+++ b/src/lib/app/mainapplication.h
@@ -110,6 +110,8 @@ public:
     DesktopNotificationsFactory* desktopNotifications();
     QWebEngineProfile* webProfile() const;
 
+    QByteArray saveState() const;
+
     static MainApplication* instance();
 
 public slots:
@@ -122,8 +124,6 @@ public slots:
     void changeOccurred();
     void quitApplication();
 
-    void writeCurrentSession(const QString &filePath);
-
 signals:
     void settingsReloaded();
     void activeWindowChanged(BrowserWindow* window);
@@ -131,7 +131,6 @@ signals:
 private slots:
     void postLaunch();
 
-    void saveSession();
     void saveSettings();
 
     void messageReceived(const QString &message);
@@ -152,7 +151,6 @@ private:
     void loadTheme(const QString &name);
 
     void translateApp();
-    void backupSavedSessions();
 
     void setUserStyleSheet(const QString &filePath);
 

--- a/src/lib/app/mainapplication.h
+++ b/src/lib/app/mainapplication.h
@@ -49,6 +49,7 @@ class HTML5PermissionsManager;
 class RegisterQAppAssociation;
 class DesktopNotificationsFactory;
 class ProxyStyle;
+class SessionManager;
 
 class QUPZILLA_EXPORT MainApplication : public QtSingleApplication
 {
@@ -101,6 +102,7 @@ public:
 
     NetworkManager* networkManager();
     RestoreManager* restoreManager();
+    SessionManager* sessionManager();
     DownloadManager* downloadManager();
     UserAgentManager* userAgentManager();
     SearchEnginesManager* searchEnginesManager();
@@ -173,6 +175,7 @@ private:
 
     NetworkManager* m_networkManager;
     RestoreManager* m_restoreManager;
+    SessionManager* m_sessionManager;
     DownloadManager* m_downloadManager;
     UserAgentManager* m_userAgentManager;
     SearchEnginesManager* m_searchEnginesManager;

--- a/src/lib/app/mainapplication.h
+++ b/src/lib/app/mainapplication.h
@@ -60,7 +60,8 @@ public:
         OpenBlankPage = 0,
         OpenHomePage = 1,
         OpenSpeedDial = 2,
-        RestoreSession = 3
+        RestoreSession = 3,
+        SelectSession = 4
     };
 
     explicit MainApplication(int &argc, char** argv);

--- a/src/lib/app/mainmenu.cpp
+++ b/src/lib/app/mainmenu.cpp
@@ -532,6 +532,10 @@ void MainMenu::init()
     m_menuFile->addSeparator();
 
     if (!mApp->isPrivate()) {
+        action = new QAction(tr("New Session..."), this);
+        connect(action, SIGNAL(triggered()), mApp->sessionManager(), SLOT(newSession()));
+        m_actions[QSL("File/NewSession")] = action;
+        m_menuFile->addAction(action);
         action = new QAction(tr("Save Session..."), this);
         connect(action, SIGNAL(triggered()), mApp->sessionManager(), SLOT(saveSession()));
         m_actions[QSL("File/SaveSession")] = action;

--- a/src/lib/app/mainmenu.cpp
+++ b/src/lib/app/mainmenu.cpp
@@ -33,6 +33,7 @@
 #include "qzsettings.h"
 #include "pluginproxy.h"
 #include "webinspector.h"
+#include "sessionmanager.h"
 
 #include <QApplication>
 #include <QMetaObject>
@@ -529,6 +530,18 @@ void MainMenu::init()
     ADD_ACTION("File/OpenFile", m_menuFile, QIcon::fromTheme(QSL("document-open")), tr("Open &File..."), SLOT(openFile()), "Ctrl+O");
     ADD_ACTION("File/CloseWindow", m_menuFile, QIcon::fromTheme(QSL("window-close")), tr("Close Window"), SLOT(closeWindow()), "Ctrl+Shift+W");
     m_menuFile->addSeparator();
+
+    if (!mApp->isPrivate()) {
+        action = new QAction(tr("Save Session..."), this);
+        connect(action, SIGNAL(triggered()), mApp->sessionManager(), SLOT(saveSession()));
+        m_actions[QSL("File/SaveSession")] = action;
+        m_menuFile->addAction(action);
+        QMenu* sessionsSubmenu = new QMenu(tr("Sessions"));
+        connect(sessionsSubmenu, SIGNAL(aboutToShow()), mApp->sessionManager(), SLOT(aboutToShowSessionsMenu()));
+        m_menuFile->addMenu(sessionsSubmenu);
+        m_menuFile->addSeparator();
+    }
+
     ADD_ACTION("File/SavePageAs", m_menuFile, QIcon::fromTheme(QSL("document-save")), tr("&Save Page As..."), SLOT(savePageAs()), "Ctrl+S");
     ADD_ACTION("File/SendLink", m_menuFile, QIcon::fromTheme(QSL("mail-message-new")), tr("Send Link..."), SLOT(sendLink()), "");
     ADD_ACTION("File/Print", m_menuFile, QIcon::fromTheme(QSL("document-print")), tr("&Print..."), SLOT(printPage()), "Ctrl+P");

--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -166,6 +166,7 @@ SOURCES += \
     preferences/useragentdialog.cpp \
     session/recoveryjsobject.cpp \
     session/restoremanager.cpp \
+    session/sessionmanager.cpp \
     sidebar/bookmarkssidebar.cpp \
     sidebar/historysidebar.cpp \
     sidebar/sidebar.cpp \
@@ -347,6 +348,7 @@ HEADERS  += \
     preferences/useragentdialog.h \
     session/recoveryjsobject.h \
     session/restoremanager.h \
+    session/sessionmanager.h \
     sidebar/bookmarkssidebar.h \
     sidebar/historysidebar.h \
     sidebar/sidebar.h \

--- a/src/lib/network/schemehandlers/qupzillaschemehandler.cpp
+++ b/src/lib/network/schemehandlers/qupzillaschemehandler.cpp
@@ -27,6 +27,7 @@
 #include "datapaths.h"
 #include "iconprovider.h"
 #include "useragentmanager.h"
+#include "sessionmanager.h"
 
 #include <QTimer>
 #include <QSettings>
@@ -375,7 +376,7 @@ QString QupZillaSchemeReply::configPage()
         cPage.replace(QLatin1String("%PATHS-TEXT%"),
                       QString("<dt>%1</dt><dd>%2<dd>").arg(tr("Profile"), DataPaths::currentProfilePath()) +
                       QString("<dt>%1</dt><dd>%2<dd>").arg(tr("Settings"), DataPaths::currentProfilePath() + "/settings.ini") +
-                      QString("<dt>%1</dt><dd>%2<dd>").arg(tr("Saved session"), DataPaths::currentProfilePath() + "/session.dat") +
+                      QString("<dt>%1</dt><dd>%2<dd>").arg(tr("Saved session"), SessionManager::defaultSessionPath()) +
                       QString("<dt>%1</dt><dd>%2<dd>").arg(tr("Pinned tabs"), DataPaths::currentProfilePath() + "/pinnedtabs.dat") +
                       QString("<dt>%1</dt><dd>%2<dd>").arg(tr("Data"), DataPaths::path(DataPaths::AppData)) +
                       QString("<dt>%1</dt><dd>%2<dd>").arg(tr("Themes"), DataPaths::path(DataPaths::Themes)) +

--- a/src/lib/preferences/preferences.ui
+++ b/src/lib/preferences/preferences.ui
@@ -318,6 +318,11 @@
                <string>Restore session</string>
               </property>
              </item>
+             <item>
+              <property name="text">
+               <string>Select session</string>
+              </property>
+             </item>
             </widget>
            </item>
            <item row="2" column="1">

--- a/src/lib/session/restoremanager.cpp
+++ b/src/lib/session/restoremanager.cpp
@@ -22,10 +22,10 @@
 
 #include <QFile>
 
-RestoreManager::RestoreManager()
+RestoreManager::RestoreManager(const QString &file)
     : m_recoveryObject(new RecoveryJsObject(this))
 {
-    createFromFile(DataPaths::currentProfilePath() + QLatin1String("/session.dat"));
+    createFromFile(file);
 }
 
 RestoreManager::~RestoreManager()

--- a/src/lib/session/restoremanager.h
+++ b/src/lib/session/restoremanager.h
@@ -34,7 +34,7 @@ public:
         QVector<WebTab::SavedTab> tabsState;
     };
 
-    explicit RestoreManager();
+    explicit RestoreManager(const QString &file);
     virtual ~RestoreManager();
 
     bool isValid() const;

--- a/src/lib/session/sessionmanager.cpp
+++ b/src/lib/session/sessionmanager.cpp
@@ -260,6 +260,34 @@ void SessionManager::saveSession()
     }
 }
 
+void SessionManager::newSession()
+{
+    bool ok;
+    QString sessionName = QInputDialog::getText(mApp->activeWindow(), tr("New Session"),
+                                         tr("Please enter a name to create new session:"), QLineEdit::Normal,
+                                         tr("New Session (%1)").arg(QDateTime::currentDateTime().toString("dd MMM yyyy HH-mm-ss")), &ok);
+
+    if (ok) {
+        const QString filePath = QString("%1/%2.dat").arg(DataPaths::path(DataPaths::Sessions)).arg(sessionName);
+        if (QFile::exists(filePath)) {
+            QMessageBox::information(mApp->activeWindow(), tr("Error!"), tr("The session file \"%1\" exists. Please enter another name.").arg(sessionName));
+            newSession();
+            return;
+        }
+
+        writeCurrentSession(m_lastActiveSessionPath);
+
+        BrowserWindow* window = mApp->createWindow(Qz::BW_NewWindow);
+        for (BrowserWindow* win : mApp->windows()) {
+            if (win != window)
+                win->close();
+        }
+
+        m_lastActiveSessionPath = filePath;
+        autoSaveLastSession();
+    }
+}
+
 void SessionManager::fillSessionsMetaDataListIfNeeded()
 {
     if (m_sessionsMetaDataList.isEmpty()) {

--- a/src/lib/session/sessionmanager.cpp
+++ b/src/lib/session/sessionmanager.cpp
@@ -1,0 +1,258 @@
+/* ============================================================
+* QupZilla - Qt web browser
+* Copyright (C) 2017  Razi Alavizadeh <s.r.alavizadeh@gmail.com>
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+* ============================================================ */
+#include "browserwindow.h"
+#include "datapaths.h"
+#include "mainapplication.h"
+#include "restoremanager.h"
+#include "sessionmanager.h"
+
+#include <QAction>
+#include <QDateTime>
+#include <QDir>
+#include <QFileSystemWatcher>
+#include <QInputDialog>
+#include <QMenu>
+#include <QMessageBox>
+
+
+SessionManager::SessionManager(QObject* parent)
+    : QObject(parent)
+    , m_firstBackupSession(DataPaths::currentProfilePath() + QL1S("/session.dat.old"))
+    , m_secondBackupSession(DataPaths::currentProfilePath() + QL1S("/session.dat.old1"))
+{
+    QFileSystemWatcher* sessionFilesWatcher = new QFileSystemWatcher({DataPaths::path(DataPaths::Sessions)}, this);
+    connect(sessionFilesWatcher, SIGNAL(directoryChanged(QString)), this, SLOT(sessionsDirectoryChanged()));
+}
+
+static void addSessionSubmenu(QObject* receiver, QMenu* menu, const QString &title, const QString &filePath)
+{
+    QMenu* sessionSubmenu = new QMenu(title, menu);
+    QObject::connect(sessionSubmenu, SIGNAL(aboutToShow()), receiver, SLOT(aboutToShowSessionSubmenu()));
+
+    QAction* action = menu->addMenu(sessionSubmenu);
+    action->setData(filePath);
+}
+
+static void addSessionsMetaDataToMenu(QObject* receiver, QMenu* menu, const QList<SessionManager::SessionMetaData> &sessionsMetaDataList)
+{
+    for (const SessionManager::SessionMetaData &metaData : sessionsMetaDataList) {
+        addSessionSubmenu(receiver, menu, metaData.name, metaData.filePath);
+    }
+}
+
+void SessionManager::aboutToShowSessionsMenu()
+{
+    QMenu* menu = qobject_cast<QMenu*>(sender());
+    menu->clear();
+
+    fillSessionsMetaDataListIfNeeded();
+
+    addSessionsMetaDataToMenu(this, menu, m_sessionsMetaDataList);
+
+    menu->addSeparator();
+
+    if (QFile::exists(m_firstBackupSession))
+        addSessionSubmenu(this, menu, tr("First Backup"), m_firstBackupSession);
+    if (QFile::exists(m_secondBackupSession))
+        addSessionSubmenu(this, menu, tr("Second Backup"), m_secondBackupSession);
+}
+
+void SessionManager::aboutToShowSessionSubmenu()
+{
+    QMenu* menu = qobject_cast<QMenu*>(sender());
+    menu->clear();
+
+    const QString sessionFilePath = menu->menuAction()->data().toString();
+    const QFileInfo sessionFileInfo(sessionFilePath);
+
+    QList<QAction*> actions;
+    QAction* action;
+
+    action = new QAction(SessionManager::tr("Open"));
+    action->setData(sessionFilePath);
+    QObject::connect(action, SIGNAL(triggered(bool)), this, SLOT(openSession()));
+    actions << action;
+
+    action = new QAction;
+    action->setSeparator(true);
+    actions << action;
+
+    action = new QAction(SessionManager::tr("Clone"));
+    action->setData(sessionFilePath);
+    QObject::connect(action, SIGNAL(triggered(bool)), this, SLOT(cloneSession()));
+    actions << action;
+
+    action = new QAction(SessionManager::tr("Rename"));
+    action->setData(sessionFilePath);
+    QObject::connect(action, SIGNAL(triggered(bool)), this, SLOT(renameSession()));
+    actions << action;
+
+    if (sessionFileInfo != QFileInfo(defaultSessionPath()) && sessionFileInfo != QFileInfo(m_firstBackupSession) && sessionFileInfo != QFileInfo(m_secondBackupSession)) {
+        action = new QAction(SessionManager::tr("Remove"));
+        action->setData(sessionFilePath);
+        QObject::connect(action, SIGNAL(triggered(bool)), this, SLOT(deleteSession()));
+        actions << action;
+    }
+
+    menu->addActions(actions);
+}
+
+void SessionManager::sessionsDirectoryChanged()
+{
+    m_sessionsMetaDataList.clear();
+}
+
+void SessionManager::openSession(QString sessionFilePath)
+{
+    if (sessionFilePath.isEmpty()) {
+        QAction* action = qobject_cast<QAction*>(sender());
+        if (!action)
+            return;
+
+        sessionFilePath = action->data().toString();
+    }
+
+    QVector<RestoreManager::WindowData> sessionData;
+    RestoreManager::createFromFile(sessionFilePath, sessionData);
+
+    if (!sessionData.isEmpty()) {
+        BrowserWindow* window = mApp->getWindow();
+        mApp->openSession(window, sessionData);
+    }
+}
+
+void SessionManager::renameSession(QString &sessionFilePath, bool clone)
+{
+    if (sessionFilePath.isEmpty()) {
+        QAction* action = qobject_cast<QAction*>(sender());
+        if (!action)
+            return;
+
+        sessionFilePath = action->data().toString();
+    }
+
+    bool ok;
+    const QString suggestedName = QFileInfo(sessionFilePath).baseName() + (clone ? tr("_cloned") : tr("_renamed"));
+    QString newName = QInputDialog::getText(mApp->activeWindow(), (clone ? tr("Clone Session") : tr("Rename Session")),
+                                            tr("Please enter a new name:"), QLineEdit::Normal,
+                                            suggestedName, &ok);
+
+    if (ok) {
+        const QString newSessionPath = QString("%1/%2.dat").arg(DataPaths::path(DataPaths::Sessions)).arg(newName);
+        if (QFile::exists(newSessionPath)) {
+            QMessageBox::information(mApp->activeWindow(), tr("Error!"), tr("The session file \"%1\" exists. Please enter another name.").arg(newName));
+            renameSession(sessionFilePath, clone);
+            return;
+        }
+
+        if (clone) {
+            if (!QFile::copy(sessionFilePath, newSessionPath)) {
+                QMessageBox::information(mApp->activeWindow(), tr("Error!"), tr("An error occurred when cloning session file."));
+                return;
+            }
+        }
+        else {
+            if (!QFile::rename(sessionFilePath, newSessionPath)) {
+                QMessageBox::information(mApp->activeWindow(), tr("Error!"), tr("An error occurred when renaming session file."));
+                return;
+            }
+        }
+    }
+}
+
+void SessionManager::cloneSession()
+{
+    QAction* action = qobject_cast<QAction*>(sender());
+    if (!action)
+        return;
+
+    renameSession(action->data().toString(), true);
+}
+
+void SessionManager::deleteSession()
+{
+    QAction* action = qobject_cast<QAction*>(sender());
+    if (!action)
+        return;
+
+    const QString filePath = action->data().toString();
+
+    QMessageBox::StandardButton result = QMessageBox::information(mApp->activeWindow(), tr("Warning!"), tr("Are you sure to delete following session?\n%1")
+                                                                  .arg(QDir::toNativeSeparators(filePath)), QMessageBox::Yes | QMessageBox::No);
+    if (result == QMessageBox::Yes) {
+        QFile::remove(filePath);
+    }
+}
+
+void SessionManager::saveSession()
+{
+    bool ok;
+    QString sessionName = QInputDialog::getText(mApp->activeWindow(), tr("Save Session"),
+                                         tr("Please enter a name to save session:"), QLineEdit::Normal,
+                                         tr("Saved Session (%1)").arg(QDateTime::currentDateTime().toString("dd MMM yyyy HH-mm-ss")), &ok);
+
+    if (ok) {
+        const QString filePath = QString("%1/%2.dat").arg(DataPaths::path(DataPaths::Sessions)).arg(sessionName);
+        if (QFile::exists(filePath)) {
+            QMessageBox::information(mApp->activeWindow(), tr("Error!"), tr("The session file \"%1\" exists. Please enter another name.").arg(sessionName));
+            saveSession();
+            return;
+        }
+
+        mApp->writeCurrentSession(filePath);
+    }
+}
+
+void SessionManager::fillSessionsMetaDataListIfNeeded()
+{
+    if (m_sessionsMetaDataList.isEmpty()) {
+        QDir dir(DataPaths::path(DataPaths::Sessions));
+
+        const QFileInfoList sessionFiles = QFileInfoList() << QFileInfo(defaultSessionPath()) << dir.entryInfoList({QSL("*.*")}, QDir::Files, QDir::Time);
+
+        QStringList fileNames;
+
+        for (int i = 0; i < sessionFiles.size(); ++i) {
+            const QFileInfo &fileInfo = sessionFiles.at(i);
+            QVector<RestoreManager::WindowData> data;
+            RestoreManager::createFromFile(fileInfo.absoluteFilePath(), data);
+
+            if (!data.isEmpty()) {
+                SessionMetaData metaData;
+                metaData.name = fileInfo.baseName();
+
+                if (fileInfo == QFileInfo(defaultSessionPath()))
+                    metaData.name = tr("Last Session");
+                else if (fileNames.contains(fileInfo.baseName()))
+                    metaData.name = fileInfo.fileName();
+                else
+                    metaData.name = fileInfo.baseName();
+
+                fileNames << metaData.name;
+                metaData.filePath = fileInfo.canonicalFilePath();
+
+                m_sessionsMetaDataList << metaData;
+            }
+        }
+    }
+}
+
+QString SessionManager::defaultSessionPath()
+{
+    return DataPaths::currentProfilePath() + QL1S("/session.dat");
+}

--- a/src/lib/session/sessionmanager.cpp
+++ b/src/lib/session/sessionmanager.cpp
@@ -182,7 +182,7 @@ void SessionManager::openSession(QString sessionFilePath, bool switchSession)
     }
 }
 
-void SessionManager::renameSession(QString &sessionFilePath, bool clone)
+void SessionManager::renameSession(QString sessionFilePath, bool clone)
 {
     if (sessionFilePath.isEmpty()) {
         QAction* action = qobject_cast<QAction*>(sender());

--- a/src/lib/session/sessionmanager.h
+++ b/src/lib/session/sessionmanager.h
@@ -41,6 +41,7 @@ public:
 
     static QString defaultSessionPath();
     QString lastActiveSessionPath() const;
+    QString askSessionFromUser();
 
     void backupSavedSessions();
     void writeCurrentSession(const QString &filePath);

--- a/src/lib/session/sessionmanager.h
+++ b/src/lib/session/sessionmanager.h
@@ -1,0 +1,60 @@
+/* ============================================================
+* QupZilla - Qt web browser
+* Copyright (C) 2017  Razi Alavizadeh <s.r.alavizadeh@gmail.com>
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+* ============================================================ */
+#ifndef SESSIONMANAGER_H
+#define SESSIONMANAGER_H
+
+#include "qzcommon.h"
+
+class QAction;
+class QMenu;
+
+
+class QUPZILLA_EXPORT SessionManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit SessionManager(QObject* parent = 0);
+
+    struct SessionMetaData {
+        QString name;
+        QString filePath;
+    };
+
+    static QString defaultSessionPath();
+
+private slots:
+    void aboutToShowSessionsMenu();
+    void aboutToShowSessionSubmenu();
+    void sessionsDirectoryChanged();
+    void openSession(QString sessionFilePath = QString());
+    void renameSession(QString &sessionFilePath = QString(), bool clone = false);
+    void cloneSession();
+    void deleteSession();
+    void saveSession();
+
+private:
+    void fillSessionsMetaDataListIfNeeded();
+
+    QList<SessionMetaData> m_sessionsMetaDataList;
+
+    QString m_firstBackupSession;
+    QString m_secondBackupSession;
+};
+
+#endif // SESSIONMANAGER_H

--- a/src/lib/session/sessionmanager.h
+++ b/src/lib/session/sessionmanager.h
@@ -58,6 +58,7 @@ private slots:
     void cloneSession();
     void deleteSession();
     void saveSession();
+    void newSession();
 
 private:
     void fillSessionsMetaDataListIfNeeded();

--- a/src/lib/session/sessionmanager.h
+++ b/src/lib/session/sessionmanager.h
@@ -36,7 +36,11 @@ public:
         QString filePath;
     };
 
+    void loadSettings();
+    void saveSettings();
+
     static QString defaultSessionPath();
+    QString lastActiveSessionPath() const;
 
     void backupSavedSessions();
     void writeCurrentSession(const QString &filePath);
@@ -61,6 +65,7 @@ private:
 
     QString m_firstBackupSession;
     QString m_secondBackupSession;
+    QString m_lastActiveSessionPath;
 };
 
 #endif // SESSIONMANAGER_H

--- a/src/lib/session/sessionmanager.h
+++ b/src/lib/session/sessionmanager.h
@@ -55,7 +55,7 @@ private slots:
     void sessionsDirectoryChanged();
     void switchToSession();
     void openSession(QString sessionFilePath = QString(), bool switchSession = false);
-    void renameSession(QString &sessionFilePath = QString(), bool clone = false);
+    void renameSession(QString sessionFilePath = QString(), bool clone = false);
     void cloneSession();
     void deleteSession();
     void saveSession();

--- a/src/lib/session/sessionmanager.h
+++ b/src/lib/session/sessionmanager.h
@@ -52,7 +52,8 @@ private slots:
     void aboutToShowSessionsMenu();
     void aboutToShowSessionSubmenu();
     void sessionsDirectoryChanged();
-    void openSession(QString sessionFilePath = QString());
+    void switchToSession();
+    void openSession(QString sessionFilePath = QString(), bool switchSession = false);
     void renameSession(QString &sessionFilePath = QString(), bool clone = false);
     void cloneSession();
     void deleteSession();

--- a/src/lib/session/sessionmanager.h
+++ b/src/lib/session/sessionmanager.h
@@ -38,6 +38,12 @@ public:
 
     static QString defaultSessionPath();
 
+    void backupSavedSessions();
+    void writeCurrentSession(const QString &filePath);
+
+public slots:
+    void autoSaveLastSession();
+
 private slots:
     void aboutToShowSessionsMenu();
     void aboutToShowSessionSubmenu();

--- a/src/lib/tabwidget/tabwidget.cpp
+++ b/src/lib/tabwidget/tabwidget.cpp
@@ -787,17 +787,8 @@ QByteArray TabWidget::saveState()
         if (!webTab)
             continue;
 
-        // save state does not support saving restore tab
-        if (webTab->url().toString() == QLatin1String("qupzilla:restore")) {
-            WebTab::SavedTab tab;
-            tab.title = m_urlOnNewTab.toString();
-            tab.url = m_urlOnNewTab;
-            tabList.append(tab);
-        }
-        else {
-            WebTab::SavedTab tab(webTab);
-            tabList.append(tab);
-        }
+        WebTab::SavedTab tab(webTab);
+        tabList.append(tab);
     }
 
     QByteArray data;

--- a/src/lib/tabwidget/tabwidget.cpp
+++ b/src/lib/tabwidget/tabwidget.cpp
@@ -787,8 +787,17 @@ QByteArray TabWidget::saveState()
         if (!webTab)
             continue;
 
-        WebTab::SavedTab tab(webTab);
-        tabList.append(tab);
+        // save state does not support saving restore tab
+        if (webTab->url().toString() == QLatin1String("qupzilla:restore")) {
+            WebTab::SavedTab tab;
+            tab.title = m_urlOnNewTab.toString();
+            tab.url = m_urlOnNewTab;
+            tabList.append(tab);
+        }
+        else {
+            WebTab::SavedTab tab(webTab);
+            tabList.append(tab);
+        }
     }
 
     QByteArray data;


### PR DESCRIPTION
***This is Session Manager as a core feature.***
1. The `$CurrentProfile/session.dat` is used as default session and a fallback for non-existing session files (on startup).
2. The `$CurrentProfile/session.dat.old` and `$CurrentProfile/session.dat.old1` are same as before i.e. backup from last active session and backup from last backup.
3. All other session files are stored in `$CurrentProfile/sessions`
4. `Open` action will open windows/tabs in current active session.
5. `Switch To` action will save current session -> close all windows ->then load selected session
6. User can not switch to backup sessions as they are overwritten by application.
7. Also deleting of backup sessions and default session is not available.
8. `Select session` is added to `after launch` that will ask about startup session after starting QupZilla.

**P.S.** I don't like the last commit  338e552 but I could not find a better solution.
