### PR TITLE
Ci faster mac win builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,19 +32,26 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
          echo "Calling brew update...";
          brew update;
+         brew outdated openssl || brew upgrade openssl;
          brew install ccache;
          PATH="/usr/local/opt/ccache/libexec:$PATH";
 
          if [[ "$QT" == "qt58" ]]; then
               QT_VER=5.8;
-              export QTDIR="$HOME/Qt/$QT_VER/clang_64";
-              brew outdated openssl || brew upgrade openssl;
-              QT_INSTALLER_FILE_NAME=qt-opensource-mac-x64-clang-$QT_VER.0;
-              wget "http://download.qt.io/official_releases/qt/$QT_VER/$QT_VER.0/$QT_INSTALLER_FILE_NAME.dmg";
-              hdiutil attach -noverify $QT_INSTALLER_FILE_NAME.dmg;
-              QT_INSTALLER=/Volumes/$QT_INSTALLER_FILE_NAME/$QT_INSTALLER_FILE_NAME.app/Contents/MacOS/$QT_INSTALLER_FILE_NAME;
-              echo "Silently installing Qt...";
-              travis_wait $QT_INSTALLER --script $QZ_DIR/mac/qt-mac-silent-install.qs;
+              if [ -z "$TRAVIS_TAG" ]; then
+                  echo "Using Homebrew Qt...";
+                  brew install qt5;
+                  export QTDIR=/usr/local/opt/qt5;
+              else
+                  echo "Using official Qt installer...";
+                  QT_INSTALLER_FILE_NAME=qt-opensource-mac-x64-clang-$QT_VER.0;
+                  wget "http://download.qt.io/official_releases/qt/$QT_VER/$QT_VER.0/$QT_INSTALLER_FILE_NAME.dmg";
+                  hdiutil attach -noverify $QT_INSTALLER_FILE_NAME.dmg;
+                  QT_INSTALLER=/Volumes/$QT_INSTALLER_FILE_NAME/$QT_INSTALLER_FILE_NAME.app/Contents/MacOS/$QT_INSTALLER_FILE_NAME;
+                  echo "Silently installing Qt...";
+                  travis_wait $QT_INSTALLER --script $QZ_DIR/mac/qt-mac-silent-install.qs;
+                  export QTDIR="$HOME/Qt/$QT_VER/clang_64";
+              fi
          fi
     fi
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: 2.1.99.{build}-{branch}
+shallow_clone: true
 
 cache:
   - windows/dependencies

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -91,11 +91,13 @@ after_build:
   # prepare qtwebengine_dictionaries 
   - mkdir qtwebengine_dictionaries
   - cd qtwebengine_dictionaries
-  - 7z x ..\..\dependencies\master.tar.gz
-  - 7z x master.tar
-  - mkdir doc
-  - move README* doc\
-  - move COPYING* doc\
+  - IF /I "%APPVEYOR_REPO_TAG%" == "true" (
+        7z x "%QZ_DIR%\windows\dependencies\master.tar.gz" &&
+        7z x "master.tar" &&
+        mkdir "doc" &&
+        move README* "doc\" &&
+        move COPYING* "doc\"
+    )
   - cd %QZ_DIR%\windows
   # set paths
   - set OPENSSL_BIN_DIR="%OPENSSL_DIR%\bin"
@@ -104,10 +106,12 @@ after_build:
   - IF /I "%ARCH%" == "x64" (set INSTALLER_VERSION="%QZ_VER% x64" && set ICU_BIN_DIR="%QZ_DIR%\windows\wininstall\icu\bin64") else (set INSTALLER_VERSION="%QZ_VER%")
   - set QTWEBENGINE_DICTIONARIES_DIR="%QZ_DIR%\windows\wininstall\qtwebengine_dictionaries"
   # make installer
-  - IF /I "%PORTABLE_BUILD%" == "true" (
-        call "C:\Program Files (x86)\NSIS\makensis.exe" /X"Unicode true" /DCUSTOM=1 /DPORTABLE=1 /DVERSION="%QZ_VER% Portable" /DARCH=%ARCH% /DMSVC_VER=%VSVER%0 /DOPENSSL_BIN_DIR=%OPENSSL_BIN_DIR% /DMSVC_REDIST_DIR=%MSVC_REDIST_DIR% /DQZ_BIN_DIR=%QZ_DIR%\bin /DICU_BIN_DIR=%ICU_BIN_DIR% /DQT_DIR=%QTDIR% /DQT_BIN_DIR=%QTDIR%\bin /DQT_PLUGINS_DIR=%QTDIR%\plugins /DQTWEBENGINE_DICTIONARIES_DIR=%QTWEBENGINE_DICTIONARIES_DIR% installer.nsi
-    ) else (
-        call "C:\Program Files (x86)\NSIS\makensis.exe" /X"Unicode true" /DCUSTOM=1 /DVERSION=%INSTALLER_VERSION% /DARCH=%ARCH% /DMSVC_VER=%VSVER%0 /DOPENSSL_BIN_DIR=%OPENSSL_BIN_DIR% /DMSVC_REDIST_DIR=%MSVC_REDIST_DIR% /DQZ_BIN_DIR=%QZ_DIR%\bin /DICU_BIN_DIR=%ICU_BIN_DIR% /DQT_DIR=%QTDIR% /DQT_BIN_DIR=%QTDIR%\bin /DQT_PLUGINS_DIR=%QTDIR%\plugins /DQTWEBENGINE_DICTIONARIES_DIR=%QTWEBENGINE_DICTIONARIES_DIR% installer.nsi
+  - IF /I "%APPVEYOR_REPO_TAG%" == "true" (
+        IF /I "%PORTABLE_BUILD%" == "true" (
+            call "C:\Program Files (x86)\NSIS\makensis.exe" /X"Unicode true" /DCUSTOM=1 /DPORTABLE=1 /DVERSION="%QZ_VER% Portable" /DARCH=%ARCH% /DMSVC_VER=%VSVER%0 /DOPENSSL_BIN_DIR=%OPENSSL_BIN_DIR% /DMSVC_REDIST_DIR=%MSVC_REDIST_DIR% /DQZ_BIN_DIR=%QZ_DIR%\bin /DICU_BIN_DIR=%ICU_BIN_DIR% /DQT_DIR=%QTDIR% /DQT_BIN_DIR=%QTDIR%\bin /DQT_PLUGINS_DIR=%QTDIR%\plugins /DQTWEBENGINE_DICTIONARIES_DIR=%QTWEBENGINE_DICTIONARIES_DIR% installer.nsi
+        ) else (
+            call "C:\Program Files (x86)\NSIS\makensis.exe" /X"Unicode true" /DCUSTOM=1 /DVERSION=%INSTALLER_VERSION% /DARCH=%ARCH% /DMSVC_VER=%VSVER%0 /DOPENSSL_BIN_DIR=%OPENSSL_BIN_DIR% /DMSVC_REDIST_DIR=%MSVC_REDIST_DIR% /DQZ_BIN_DIR=%QZ_DIR%\bin /DICU_BIN_DIR=%ICU_BIN_DIR% /DQT_DIR=%QTDIR% /DQT_BIN_DIR=%QTDIR%\bin /DQT_PLUGINS_DIR=%QTDIR%\plugins /DQTWEBENGINE_DICTIONARIES_DIR=%QTWEBENGINE_DICTIONARIES_DIR% installer.nsi
+        )
     )
 
 artifacts:
@@ -140,3 +144,11 @@ deploy:
     # on_build_success: false
     # on_build_failure: false
     # on_build_status_changed: true
+
+# # remote desktop connection on init
+# init:
+  # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+# # remote desktop connection on finish and block build to not destroy VM
+# on_finish:
+  # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))


### PR DESCRIPTION
 **OSX:** As we just deploy on pushing new tags so all other builds can use Homebrew qt that is a much smaller file to download.
**Windows:** As we just deploy on pushing new tags so for all other builds we don't need to make installer.

**‌Before:**

![win_before](https://cloud.githubusercontent.com/assets/1328454/24807898/43a63bd4-1bcf-11e7-91db-86f662cdf5a9.PNG)

![osx_before](https://cloud.githubusercontent.com/assets/1328454/24807911/4f6fc78c-1bcf-11e7-90a5-c5ab563da5bd.PNG)

**‌After:**

![win_after](https://cloud.githubusercontent.com/assets/1328454/24807938/621d2226-1bcf-11e7-956d-d12066143069.PNG)

![osx_after](https://cloud.githubusercontent.com/assets/1328454/24807944/6a5d9a56-1bcf-11e7-9f0b-03855b18e786.PNG)


