### PR TITLE
Support QtWebEngine 5.8 with Qt 5.7

### DIFF
--- a/src/defines.pri
+++ b/src/defines.pri
@@ -35,6 +35,10 @@ equals(d_disable_dbus, "true") { DEFINES *= DISABLE_DBUS }
 equals(d_disable_updates_check, "true") { DEFINES *= DISABLE_UPDATES_CHECK }
 equals(d_debug_build, "true") { CONFIG += debug }
 
+!lessThan(QT.webengine.VERSION, 5.8) {
+    DEFINES *= HAVE_QTWEBENGINE_58
+}
+
 DEFINES *= QT_NO_URL_CAST_FROM_STRING
 DEFINES *= QT_USE_QSTRINGBUILDER
 

--- a/src/lib/app/mainapplication.cpp
+++ b/src/lib/app/mainapplication.cpp
@@ -920,7 +920,7 @@ void MainApplication::loadSettings()
     const int cacheSize = settings.value(QSL("Web-Browser-Settings/LocalCacheSize"), 50).toInt() * 1000 * 1000;
     profile->setHttpCacheMaximumSize(cacheSize);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+#ifdef HAVE_QTWEBENGINE_58
     settings.beginGroup(QSL("SpellCheck"));
     profile->setSpellCheckEnabled(settings.value(QSL("Enabled"), false).toBool());
     profile->setSpellCheckLanguages(settings.value(QSL("Languages")).toStringList());

--- a/src/lib/downloads/downloadmanager.cpp
+++ b/src/lib/downloads/downloadmanager.cpp
@@ -258,7 +258,7 @@ void DownloadManager::download(QWebEngineDownloadItem *downloadItem)
     // Filename may have been percent encoded and actually containing path
     fileName = QFileInfo(fileName).fileName();
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+#ifdef HAVE_QTWEBENGINE_58
     const bool forceAsk = downloadItem->savePageFormat() != QWebEngineDownloadItem::UnknownSaveFormat
             || downloadItem->type() == QWebEngineDownloadItem::UserRequested;
 #else
@@ -274,7 +274,7 @@ void DownloadManager::download(QWebEngineDownloadItem *downloadItem)
         if (downloadItem->savePageFormat() != QWebEngineDownloadItem::UnknownSaveFormat) {
             // Save Page requested
             result = SavePage;
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+#ifdef HAVE_QTWEBENGINE_58
         } else if (downloadItem->type() == QWebEngineDownloadItem::UserRequested) {
             // Save x as... requested
             result = Save;

--- a/src/lib/preferences/preferences.cpp
+++ b/src/lib/preferences/preferences.cpp
@@ -404,7 +404,7 @@ Preferences::Preferences(BrowserWindow* window)
     m_notifPosition = settings.value("Position", QPoint(10, 10)).toPoint();
     settings.endGroup();
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+#ifdef HAVE_QTWEBENGINE_58
     //SPELLCHECK
     settings.beginGroup(QSL("SpellCheck"));
     ui->spellcheckEnabled->setChecked(settings.value(QSL("Enabled"), false).toBool());
@@ -1008,7 +1008,7 @@ void Preferences::saveSettings()
     settings.setValue("Position", m_notification.data() ? m_notification.data()->pos() : m_notifPosition);
     settings.endGroup();
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+#ifdef HAVE_QTWEBENGINE_58
     //SPELLCHECK
     settings.beginGroup(QSL("SpellCheck"));
     settings.setValue("Enabled", ui->spellcheckEnabled->isChecked());

--- a/src/lib/webengine/webview.cpp
+++ b/src/lib/webengine/webview.cpp
@@ -518,7 +518,7 @@ void WebView::showSource()
         return;
     }
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+#ifdef HAVE_QTWEBENGINE_58
     triggerPageAction(QWebEnginePage::ViewSource);
 #else
     QUrl u;
@@ -647,7 +647,7 @@ void WebView::createContextMenu(QMenu *menu, WebHitTestResult &hitTest)
     const QWebEngineContextMenuData &contextMenuData = page()->contextMenuData();
     hitTest.updateWithContextMenuData(contextMenuData);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+#ifdef HAVE_QTWEBENGINE_58
     if (!contextMenuData.misspelledWord().isEmpty()) {
         QFont boldFont = menu->font();
         boldFont.setBold(true);


### PR DESCRIPTION
Check QT.webengine.VERSION in defines.pri instead of relying on QT_VERSION_CHECK. This allows using QtWebEngine 5.8 functionality on Qt 5.7.

This pull request is for v2.1 only, because master requires Qt 5.8 to begin with.