### PR TITLE
Fix compilation with KDE in custom prefix

### DIFF
--- a/src/plugins/KWalletPasswords/kwalletpasswordbackend.cpp
+++ b/src/plugins/KWalletPasswords/kwalletpasswordbackend.cpp
@@ -21,7 +21,7 @@
 #include <QDateTime>
 
 #if QT_VERSION >= 0x050000
-#include <KF5/KWallet/KWallet>
+#include <KWallet>
 #else
 #include <KDE/KWallet/Wallet>
 #endif


### PR DESCRIPTION
The .pri file for KWallet brings in the correct include path for
that framework, while KF5/KWallet/KWallet only works with a /usr/include
base dir.