### PR TITLE
Add missing RUNPATH so that qupzilla finds its shared lib

### DIFF
--- a/src/main/main.pro
+++ b/src/main/main.pro
@@ -40,4 +40,10 @@ openbsd-*|freebsd-*|haiku-* {
 
 include(../install.pri)
 
-unix:contains(DEFINES, "NO_SYSTEM_DATAPATH"): QMAKE_LFLAGS+=$${QMAKE_LFLAGS_RPATH}\\$\$ORIGIN
+unix:contains(DEFINES, "NO_SYSTEM_DATAPATH") {
+   # For running the app without installing it
+   QMAKE_LFLAGS+=$${QMAKE_LFLAGS_RPATH}\\$\$ORIGIN
+   # For running the app after installation
+   QMAKE_LFLAGS+=$${QMAKE_LFLAGS_RPATH}$${library_folder}
+   message(QMAKE_LFLAGS: $$QMAKE_LFLAGS)
+}


### PR DESCRIPTION
when installed into a custom prefix, on Linux.

If qupzilla used cmake and ECM, this would have worked out of the box :-)

I actually volunteer to port qupzilla to cmake (qmake + env vars is rather cumbersome), but I would only test it on Linux, it would have to be tested by others on other platforms.

(Alternatively if qmake is kept, we could port to the Qt 5.8 configure system to improve upon the env var solution.)