### PR TITLE
Windows: At first try to show native default app settings UI (>=Vista).

### DIFF
--- a/src/lib/app/mainapplication.cpp
+++ b/src/lib/app/mainapplication.cpp
@@ -1092,7 +1092,8 @@ void MainApplication::checkDefaultWebBrowser()
         dialog.setIcon(QMessageBox::Warning);
 
         if (dialog.exec() == QMessageBox::Yes) {
-            associationManager()->registerAllAssociation();
+            if (!mApp->associationManager()->showNativeDefaultAppSettingsUi())
+                mApp->associationManager()->registerAllAssociation();
         }
 
         checkAgain = dialog.isChecked();

--- a/src/lib/other/registerqappassociation.h
+++ b/src/lib/other/registerqappassociation.h
@@ -1,5 +1,5 @@
 /* ============================================================
-* Copyright (C) 2012-2014  S. Razi Alavizadeh <s.r.alavizadeh@gmail.com>
+* Copyright (C) 2012-2017  S. Razi Alavizadeh <s.r.alavizadeh@gmail.com>
 * This file is part of QupZilla - WebKit based browser 2010-2014
 * by  David Rosca <nowrep@gmail.com>
 *
@@ -50,6 +50,7 @@ public:
     void setPerMachineRegisteration(bool enable);
     bool registerAppCapabilities();
     bool isVistaOrNewer();
+    bool isWin10OrNewer();
     void registerAssociation(const QString &assocName, AssociationType type);
     void createProgId(const QString &progId);
 
@@ -57,6 +58,7 @@ public:
     bool isDefaultForAllCapabilities();
     void registerAllAssociation();
 
+    bool showNativeDefaultAppSettingsUi();
 
 private:
     QString _appRegisteredName;

--- a/src/lib/preferences/preferences.cpp
+++ b/src/lib/preferences/preferences.cpp
@@ -611,9 +611,11 @@ void Preferences::makeQupZillaDefault()
 {
 #if defined(Q_OS_WIN) && !defined(Q_OS_OS2)
     disconnect(ui->checkNowDefaultBrowser, SIGNAL(clicked()), this, SLOT(makeQupZillaDefault()));
-    mApp->associationManager()->registerAllAssociation();
     ui->checkNowDefaultBrowser->setText(tr("Default"));
     ui->checkNowDefaultBrowser->setEnabled(false);
+
+    if (!mApp->associationManager()->showNativeDefaultAppSettingsUi())
+        mApp->associationManager()->registerAllAssociation();
 #endif
 }
 


### PR DESCRIPTION
The main part of this patch has been taken from Firefox source code ([here](https://github.com/mozilla/gecko-dev/blob/master/browser/components/shell/nsWindowsShellService.cpp#L364)) that is licensed under MPL-2.0. Is it OK merging MPL code into GPL code?

I tested it under Windows 10 and WIndows server 2012 (that has same API like win8).