### PR TITLE
Cleanup processinfo.h includes

### DIFF
--- a/src/lib/3rdparty/processinfo.h
+++ b/src/lib/3rdparty/processinfo.h
@@ -18,15 +18,11 @@
 #ifndef PROCESSINFO_H
 #define PROCESSINFO_H
 
-#include <QtGlobal>
+#include "qzcommon.h"
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
 #include <sys/types.h>
 #endif
-
-#include <QString>
-
-#include "qzcommon.h"
 
 /*
  * Code used from http://ubuntuforums.org/showpost.php?p=6593782&postcount=5


### PR DESCRIPTION
Cleanup the includes:
QtGlobal is not needed - already pulled in by qzcommon.h
QString not needed, already pulled in by qzcommon.h
Move the qzcommon include before the ifdefs

This is a change that has been getting used when building QupZilla on FreeBSD for several years now and works fine.

I was reviewing the FreeBSD port in preparation for the switchover to the new repository/name and discovered this patch. After a quick review that this patch is nothing FreeBSD-specific (just some C/C++ cleanup), I wanted to ensure this got submitted upstream ASAP.

I was originally going to submit this to the new Falkon repository, but after a fair bit of time in the KDE docs I am still unable to figure out how contributors are supposed to be able to send in patches (even with a ton of experience with Qt/Git). 

If you could please make sure this patch is applied to the new repo as well that would be awesome.