### PR TITLE
Improve TabManager

### DIFF
--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -176,6 +176,7 @@ SOURCES += \
     tabwidget/tabicon.cpp \
     tabwidget/tabstackedwidget.cpp \
     tabwidget/tabwidget.cpp \
+    tabwidget/tabcontextmenu.cpp \
     tools/aesinterface.cpp \
     tools/animatedwidget.cpp \
     tools/buttonbox.cpp \
@@ -361,6 +362,7 @@ HEADERS  += \
     tabwidget/tabicon.h \
     tabwidget/tabstackedwidget.h \
     tabwidget/tabwidget.h \
+    tabwidget/tabcontextmenu.h \
     tools/aesinterface.h \
     tools/animatedwidget.h \
     tools/buttonbox.h \

--- a/src/lib/tabwidget/tabbar.h
+++ b/src/lib/tabwidget/tabbar.h
@@ -1,6 +1,6 @@
 /* ============================================================
 * QupZilla - WebKit based browser
-* Copyright (C) 2010-2016 David Rosca <nowrep@gmail.com>
+* Copyright (C) 2010-2017 David Rosca <nowrep@gmail.com>
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -19,8 +19,6 @@
 #define TABBAR_H
 
 #include "combotabbar.h"
-
-#include <QRect>
 
 #include "qzcommon.h"
 
@@ -49,33 +47,11 @@ public:
     void wheelEvent(QWheelEvent* event);
 
 signals:
-    void reloadTab(int index);
-    void stopTab(int index);
-    void closeAllButCurrent(int index);
-    void closeToRight(int index);
-    void closeToLeft(int index);
-    void duplicateTab(int index);
-    void detachTab(int index);
-
     void moveAddTabButton(int posX);
 
 private slots:
     void currentTabChanged(int index);
     void overflowChanged(bool overflowed);
-
-    void reloadTab() { emit reloadTab(m_clickedTab); }
-    void stopTab() { emit stopTab(m_clickedTab); }
-    void closeTab() { emit tabCloseRequested(m_clickedTab); }
-    void duplicateTab() { emit duplicateTab(m_clickedTab); }
-    void detachTab() { emit detachTab(m_clickedTab); }
-
-    void pinTab();
-    void muteTab();
-
-    void closeCurrentTab();
-    void closeAllButCurrent();
-    void closeToRight();
-    void closeToLeft();
     void closeTabFromButton();
 
 private:
@@ -106,7 +82,6 @@ private:
     bool m_hideTabBarWithOneTab;
 
     int m_showCloseOnInactive;
-    int m_clickedTab;
 
     mutable int m_normalTabWidth;
     mutable int m_activeTabWidth;

--- a/src/lib/tabwidget/tabcontextmenu.cpp
+++ b/src/lib/tabwidget/tabcontextmenu.cpp
@@ -27,12 +27,13 @@
 #include "checkboxdialog.h"
 
 
-TabContextMenu::TabContextMenu(int index, Qt::Orientation orientation, BrowserWindow* window, TabWidget* tabWidget)
+TabContextMenu::TabContextMenu(int index, Qt::Orientation orientation, BrowserWindow* window, TabWidget* tabWidget, bool showCloseOtherTabs)
     : QMenu()
     , m_clickedTab(index)
     , m_tabsOrientation(orientation)
     , m_window(window)
     , m_tabWidget(tabWidget)
+    , m_showCloseOtherTabs(showCloseOtherTabs)
 {
     setObjectName("tabcontextmenu");
 
@@ -129,10 +130,14 @@ void TabContextMenu::init()
         addAction(tr("Re&load All Tabs"), m_tabWidget, SLOT(reloadAllTabs()));
         addAction(tr("Bookmark &All Tabs"), m_window, SLOT(bookmarkAllTabs()));
         addSeparator();
-        addAction(tr("Close Ot&her Tabs"), this, SLOT(closeAllButCurrent()));
-        addAction(m_tabsOrientation == Qt::Horizontal ? tr("Close Tabs To The Right") : tr("Close Tabs To The Bottom"), this, SLOT(closeToRight()));
-        addAction(m_tabsOrientation == Qt::Horizontal ? tr("Close Tabs To The Left") : tr("Close Tabs To The Top"), this, SLOT(closeToLeft()));
-        addSeparator();
+
+        if (m_showCloseOtherTabs) {
+            addAction(tr("Close Ot&her Tabs"), this, SLOT(closeAllButCurrent()));
+            addAction(m_tabsOrientation == Qt::Horizontal ? tr("Close Tabs To The Right") : tr("Close Tabs To The Bottom"), this, SLOT(closeToRight()));
+            addAction(m_tabsOrientation == Qt::Horizontal ? tr("Close Tabs To The Left") : tr("Close Tabs To The Top"), this, SLOT(closeToLeft()));
+            addSeparator();
+        }
+
         addAction(m_window->action(QSL("Other/RestoreClosedTab")));
         addAction(QIcon::fromTheme("window-close"), tr("Cl&ose Tab"), this, SLOT(closeTab()));
     } else {

--- a/src/lib/tabwidget/tabcontextmenu.cpp
+++ b/src/lib/tabwidget/tabcontextmenu.cpp
@@ -1,0 +1,166 @@
+/* ============================================================
+* QupZilla - Qt web browser
+* Copyright (C) 2010-2017 David Rosca <nowrep@gmail.com>
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+* ============================================================ */
+#include "tabcontextmenu.h"
+#include "tabbar.h"
+#include "tabwidget.h"
+#include "browserwindow.h"
+#include "webtab.h"
+#include "settings.h"
+#include "tabbedwebview.h"
+#include "mainapplication.h"
+#include "iconprovider.h"
+#include "checkboxdialog.h"
+
+
+TabContextMenu::TabContextMenu(int index, Qt::Orientation orientation, BrowserWindow* window, TabWidget* tabWidget)
+    : QMenu()
+    , m_clickedTab(index)
+    , m_tabsOrientation(orientation)
+    , m_window(window)
+    , m_tabWidget(tabWidget)
+{
+    setObjectName("tabcontextmenu");
+
+    connect(this, SIGNAL(tabCloseRequested(int)), m_tabWidget->tabBar(), SIGNAL(tabCloseRequested(int)));
+    connect(this, SIGNAL(reloadTab(int)), m_tabWidget, SLOT(reloadTab(int)));
+    connect(this, SIGNAL(stopTab(int)), m_tabWidget, SLOT(stopTab(int)));
+    connect(this, SIGNAL(closeAllButCurrent(int)), m_tabWidget, SLOT(closeAllButCurrent(int)));
+    connect(this, SIGNAL(closeToRight(int)), m_tabWidget, SLOT(closeToRight(int)));
+    connect(this, SIGNAL(closeToLeft(int)), m_tabWidget, SLOT(closeToLeft(int)));
+    connect(this, SIGNAL(duplicateTab(int)), m_tabWidget, SLOT(duplicateTab(int)));
+    connect(this, SIGNAL(detachTab(int)), m_tabWidget, SLOT(detachTab(int)));
+
+    init();
+}
+
+static bool canCloseTabs(const QString &settingsKey, const QString &title, const QString &description)
+{
+    Settings settings;
+    bool ask = settings.value("Browser-Tabs-Settings/" + settingsKey, true).toBool();
+
+    if (ask) {
+        CheckBoxDialog dialog(QMessageBox::Yes | QMessageBox::No, mApp->activeWindow());
+        dialog.setDefaultButton(QMessageBox::No);
+        dialog.setWindowTitle(title);
+        dialog.setText(description);
+        dialog.setCheckBoxText(TabBar::tr("Don't ask again"));
+        dialog.setIcon(QMessageBox::Question);
+
+        if (dialog.exec() != QMessageBox::Yes) {
+            return false;
+        }
+
+        if (dialog.isChecked()) {
+            settings.setValue("Browser-Tabs-Settings/" + settingsKey, false);
+        }
+    }
+
+    return true;
+}
+
+void TabContextMenu::closeAllButCurrent()
+{
+    if (canCloseTabs(QLatin1String("AskOnClosingAllButCurrent"), tr("Close Tabs"), tr("Do you really want to close other tabs?"))) {
+        emit closeAllButCurrent(m_clickedTab);
+    }
+}
+
+void TabContextMenu::closeToRight()
+{
+    const QString label = m_tabsOrientation == Qt::Horizontal
+            ? tr("Do you really want to close all tabs to the right?")
+            : tr("Do you really want to close all tabs to the bottom?");
+
+    if (canCloseTabs(QLatin1String("AskOnClosingToRight"), tr("Close Tabs"), label)) {
+        emit closeToRight(m_clickedTab);
+    }
+}
+
+void TabContextMenu::closeToLeft()
+{
+    const QString label = m_tabsOrientation == Qt::Horizontal
+            ? tr("Do you really want to close all tabs to the left?")
+            : tr("Do you really want to close all tabs to the top?");
+
+    if (canCloseTabs(QLatin1String("AskOnClosingToLeft"), tr("Close Tabs"), label)) {
+        emit closeToLeft(m_clickedTab);
+    }
+}
+
+void TabContextMenu::init()
+{
+    if (m_clickedTab != -1) {
+        WebTab* webTab = qobject_cast<WebTab*>(m_tabWidget->widget(m_clickedTab));
+        if (!webTab) {
+            return;
+        }
+
+        if (m_window->weView(m_clickedTab)->isLoading()) {
+            addAction(QIcon::fromTheme(QSL("process-stop")), tr("&Stop Tab"), this, SLOT(stopTab()));
+        }
+        else {
+            addAction(QIcon::fromTheme(QSL("view-refresh")), tr("&Reload Tab"), this, SLOT(reloadTab()));
+        }
+
+        addAction(QIcon::fromTheme("tab-duplicate"), tr("&Duplicate Tab"), this, SLOT(duplicateTab()));
+
+        if (m_tabWidget->count() > 1 && !webTab->isPinned()) {
+            addAction(QIcon::fromTheme("tab-detach"), tr("D&etach Tab"), this, SLOT(detachTab()));
+        }
+
+        addAction(webTab->isPinned() ? tr("Un&pin Tab") : tr("&Pin Tab"), this, SLOT(pinTab()));
+        addAction(webTab->isMuted() ? tr("Un&mute Tab") : tr("&Mute Tab"), this, SLOT(muteTab()));
+        addSeparator();
+        addAction(tr("Re&load All Tabs"), m_tabWidget, SLOT(reloadAllTabs()));
+        addAction(tr("Bookmark &All Tabs"), m_window, SLOT(bookmarkAllTabs()));
+        addSeparator();
+        addAction(tr("Close Ot&her Tabs"), this, SLOT(closeAllButCurrent()));
+        addAction(m_tabsOrientation == Qt::Horizontal ? tr("Close Tabs To The Right") : tr("Close Tabs To The Bottom"), this, SLOT(closeToRight()));
+        addAction(m_tabsOrientation == Qt::Horizontal ? tr("Close Tabs To The Left") : tr("Close Tabs To The Top"), this, SLOT(closeToLeft()));
+        addSeparator();
+        addAction(m_window->action(QSL("Other/RestoreClosedTab")));
+        addAction(QIcon::fromTheme("window-close"), tr("Cl&ose Tab"), this, SLOT(closeTab()));
+    } else {
+        addAction(IconProvider::newTabIcon(), tr("&New tab"), m_window, SLOT(addTab()));
+        addSeparator();
+        addAction(tr("Reloa&d All Tabs"), m_tabWidget, SLOT(reloadAllTabs()));
+        addAction(tr("Bookmark &All Tabs"), m_window, SLOT(bookmarkAllTabs()));
+        addSeparator();
+        addAction(m_window->action(QSL("Other/RestoreClosedTab")));
+    }
+
+    m_window->action(QSL("Other/RestoreClosedTab"))->setEnabled(m_tabWidget->canRestoreTab());
+}
+
+void TabContextMenu::pinTab()
+{
+    WebTab* webTab = qobject_cast<WebTab*>(m_tabWidget->widget(m_clickedTab));
+
+    if (webTab) {
+        webTab->togglePinned();
+    }
+}
+
+void TabContextMenu::muteTab()
+{
+    WebTab* webTab = qobject_cast<WebTab*>(m_tabWidget->widget(m_clickedTab));
+
+    if (webTab) {
+        webTab->toggleMuted();
+    }
+}

--- a/src/lib/tabwidget/tabcontextmenu.h
+++ b/src/lib/tabwidget/tabcontextmenu.h
@@ -1,0 +1,68 @@
+/* ============================================================
+* QupZilla - WebKit based browser
+* Copyright (C) 2010-2017 David Rosca <nowrep@gmail.com>
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+* ============================================================ */
+#ifndef TABCONTEXTMENU_H
+#define TABCONTEXTMENU_H
+
+#include <QMenu>
+
+#include "qzcommon.h"
+
+class BrowserWindow;
+class TabWidget;
+
+class QUPZILLA_EXPORT TabContextMenu : public QMenu
+{
+    Q_OBJECT
+public:
+    explicit TabContextMenu(int index, Qt::Orientation orientation, BrowserWindow* window, TabWidget* tabWidget);
+
+
+signals:
+    void reloadTab(int index);
+    void stopTab(int index);
+    void tabCloseRequested(int index);
+    void closeAllButCurrent(int index);
+    void closeToRight(int index);
+    void closeToLeft(int index);
+    void duplicateTab(int index);
+    void detachTab(int index);
+
+private slots:
+    void reloadTab() { emit reloadTab(m_clickedTab); }
+    void stopTab() { emit stopTab(m_clickedTab); }
+    void closeTab() { emit tabCloseRequested(m_clickedTab); }
+    void duplicateTab() { emit duplicateTab(m_clickedTab); }
+    void detachTab() { emit detachTab(m_clickedTab); }
+
+    void pinTab();
+    void muteTab();
+
+    void closeAllButCurrent();
+    void closeToRight();
+    void closeToLeft();
+
+private:
+    void init();
+
+    int m_clickedTab;
+    Qt::Orientation m_tabsOrientation;
+    BrowserWindow* m_window;
+    TabWidget* m_tabWidget;
+};
+
+#endif // TABCONTEXTMENU_H

--- a/src/lib/tabwidget/tabcontextmenu.h
+++ b/src/lib/tabwidget/tabcontextmenu.h
@@ -29,7 +29,7 @@ class QUPZILLA_EXPORT TabContextMenu : public QMenu
 {
     Q_OBJECT
 public:
-    explicit TabContextMenu(int index, Qt::Orientation orientation, BrowserWindow* window, TabWidget* tabWidget);
+    explicit TabContextMenu(int index, Qt::Orientation orientation, BrowserWindow* window, TabWidget* tabWidget, bool showCloseOtherTabs = true);
 
 
 signals:
@@ -63,6 +63,7 @@ private:
     Qt::Orientation m_tabsOrientation;
     BrowserWindow* m_window;
     TabWidget* m_tabWidget;
+    bool m_showCloseOtherTabs;
 };
 
 #endif // TABCONTEXTMENU_H

--- a/src/lib/tabwidget/tabwidget.cpp
+++ b/src/lib/tabwidget/tabwidget.cpp
@@ -125,13 +125,6 @@ TabWidget::TabWidget(BrowserWindow* window, QWidget* parent)
     connect(this, &TabStackedWidget::pinStateChanged, this, &TabWidget::changed);
 
     connect(m_tabBar, SIGNAL(tabCloseRequested(int)), this, SLOT(requestCloseTab(int)));
-    connect(m_tabBar, SIGNAL(reloadTab(int)), this, SLOT(reloadTab(int)));
-    connect(m_tabBar, SIGNAL(stopTab(int)), this, SLOT(stopTab(int)));
-    connect(m_tabBar, SIGNAL(closeAllButCurrent(int)), this, SLOT(closeAllButCurrent(int)));
-    connect(m_tabBar, SIGNAL(closeToRight(int)), this, SLOT(closeToRight(int)));
-    connect(m_tabBar, SIGNAL(closeToLeft(int)), this, SLOT(closeToLeft(int)));
-    connect(m_tabBar, SIGNAL(duplicateTab(int)), this, SLOT(duplicateTab(int)));
-    connect(m_tabBar, SIGNAL(detachTab(int)), this, SLOT(detachTab(int)));
     connect(m_tabBar, SIGNAL(tabMoved(int,int)), this, SLOT(tabMoved(int,int)));
 
     connect(m_tabBar, SIGNAL(moveAddTabButton(int)), this, SLOT(moveAddTabButton(int)));

--- a/src/lib/tabwidget/tabwidget.cpp
+++ b/src/lib/tabwidget/tabwidget.cpp
@@ -505,6 +505,8 @@ void TabWidget::currentTabChanged(int index)
     m_currentTabFresh = false;
 
     WebTab* webTab = weTab(index);
+    webTab->tabActivated();
+
     LocationBar* locBar = webTab->locationBar();
 
     if (locBar && m_locationBars->indexOf(locBar) != -1) {

--- a/src/lib/webtab/webtab.cpp
+++ b/src/lib/webtab/webtab.cpp
@@ -36,7 +36,6 @@
 #include <QTimer>
 #include <QSplitter>
 
-bool WebTab::s_pinningTab = false;
 static const int savedTabVersion = 3;
 
 WebTab::SavedTab::SavedTab()
@@ -474,11 +473,10 @@ void WebTab::slotRestore()
     m_tabBar->restoreTabTextColor(tabIndex());
 }
 
-void WebTab::showEvent(QShowEvent* event)
+void WebTab::tabActivated()
 {
-    QWidget::showEvent(event);
 
-    if (!isRestored() && !s_pinningTab) {
+    if (!isRestored()) {
         // When session is being restored, restore the tab immediately
         if (mApp->isRestoring()) {
             slotRestore();
@@ -515,11 +513,7 @@ void WebTab::togglePinned()
 
     m_isPinned = !m_isPinned;
 
-    // Workaround bug in TabStackedWidget when pinning tab, other tabs may be accidentaly
-    // shown and restored state even when they won't be switched to by user.
-    s_pinningTab = true;
     m_window->tabWidget()->pinUnPinTab(tabIndex(), title());
-    s_pinningTab = false;
 
     emit pinStateChanged(m_isPinned);
 }

--- a/src/lib/webtab/webtab.cpp
+++ b/src/lib/webtab/webtab.cpp
@@ -514,6 +514,4 @@ void WebTab::togglePinned()
     m_isPinned = !m_isPinned;
 
     m_window->tabWidget()->pinUnPinTab(tabIndex(), title());
-
-    emit pinStateChanged(m_isPinned);
 }

--- a/src/lib/webtab/webtab.cpp
+++ b/src/lib/webtab/webtab.cpp
@@ -520,4 +520,6 @@ void WebTab::togglePinned()
     s_pinningTab = true;
     m_window->tabWidget()->pinUnPinTab(tabIndex(), title());
     s_pinningTab = false;
+
+    emit pinStateChanged(m_isPinned);
 }

--- a/src/lib/webtab/webtab.h
+++ b/src/lib/webtab/webtab.h
@@ -128,9 +128,6 @@ private:
 
     SavedTab m_savedTab;
     bool m_isPinned;
-
-signals:
-    void pinStateChanged(bool);
 };
 
 #endif // WEBTAB_H

--- a/src/lib/webtab/webtab.h
+++ b/src/lib/webtab/webtab.h
@@ -102,6 +102,8 @@ public:
     void p_restoreTab(const SavedTab &tab);
     void p_restoreTab(const QUrl &url, const QByteArray &history, int zoomLevel);
 
+    void tabActivated();
+
 private slots:
     void showNotification(QWidget* notif);
     void loadStarted();
@@ -111,7 +113,6 @@ private slots:
     void slotRestore();
 
 private:
-    void showEvent(QShowEvent* event);
     void resizeEvent(QResizeEvent *event) override;
 
     BrowserWindow* m_window;
@@ -127,8 +128,6 @@ private:
 
     SavedTab m_savedTab;
     bool m_isPinned;
-
-    static bool s_pinningTab;
 
 signals:
     void pinStateChanged(bool);

--- a/src/lib/webtab/webtab.h
+++ b/src/lib/webtab/webtab.h
@@ -129,6 +129,9 @@ private:
     bool m_isPinned;
 
     static bool s_pinningTab;
+
+signals:
+    void pinStateChanged(bool);
 };
 
 #endif // WEBTAB_H

--- a/src/plugins/TabManager/tabmanagerdelegate.cpp
+++ b/src/plugins/TabManager/tabmanagerdelegate.cpp
@@ -111,11 +111,6 @@ void TabManagerDelegate::paint(QPainter* painter, const QStyleOptionViewItem &op
     if (!opt.text.isEmpty()) {
         const QString filterText = property("filterText").toString();
 
-        QPalette::ColorGroup cg = (opt.state & QStyle::State_Enabled) && !isSavedTab
-                              ? QPalette::Normal : QPalette::Disabled;
-        if (cg == QPalette::Normal && !(opt.state & QStyle::State_Active))
-            cg = QPalette::Inactive;
-
         if (opt.state & QStyle::State_Selected) {
             painter->setPen(opt.palette.color(cg, QPalette::HighlightedText));
         } else {

--- a/src/plugins/TabManager/tabmanagerdelegate.cpp
+++ b/src/plugins/TabManager/tabmanagerdelegate.cpp
@@ -33,13 +33,14 @@ void TabManagerDelegate::paint(QPainter* painter, const QStyleOptionViewItem &op
     QStyleOptionViewItem opt = option;
     initStyleOption(&opt, index);
 
+    const bool isSavedTab = index.data(Qt::UserRole + 1).toBool();
     const QWidget* w = opt.widget;
     const QStyle* style = w ? w->style() : QApplication::style();
     const Qt::LayoutDirection direction = w ? w->layoutDirection() : QApplication::layoutDirection();
 
     const QPalette::ColorRole colorRole = opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::Text;
 
-    QPalette::ColorGroup cg = opt.state & QStyle::State_Enabled ? QPalette::Normal : QPalette::Disabled;
+    QPalette::ColorGroup cg = (opt.state & QStyle::State_Enabled) && !isSavedTab ? QPalette::Normal : QPalette::Disabled;
     if (cg == QPalette::Normal && !(opt.state & QStyle::State_Active)) {
         cg = QPalette::Inactive;
     }
@@ -110,7 +111,7 @@ void TabManagerDelegate::paint(QPainter* painter, const QStyleOptionViewItem &op
     if (!opt.text.isEmpty()) {
         const QString filterText = property("filterText").toString();
 
-        QPalette::ColorGroup cg = opt.state & QStyle::State_Enabled
+        QPalette::ColorGroup cg = (opt.state & QStyle::State_Enabled) && !isSavedTab
                               ? QPalette::Normal : QPalette::Disabled;
         if (cg == QPalette::Normal && !(opt.state & QStyle::State_Active))
             cg = QPalette::Inactive;
@@ -124,6 +125,9 @@ void TabManagerDelegate::paint(QPainter* painter, const QStyleOptionViewItem &op
             painter->setPen(opt.palette.color(cg, QPalette::Text));
             painter->drawRect(textRect.adjusted(0, 0, -1, -1));
         }
+
+        if (isSavedTab)
+            opt.font.setItalic(true);
 
         painter->setFont(opt.font);
         viewItemDrawText(painter, &opt, textRect, opt.text, textPalette.color(colorRole), filterText);

--- a/src/plugins/TabManager/tabmanagerplugin.cpp
+++ b/src/plugins/TabManager/tabmanagerplugin.cpp
@@ -51,7 +51,7 @@ PluginSpec TabManagerPlugin::pluginSpec()
     spec.name = "Tab Manager";
     spec.info = "Simple yet powerful tab manager for QupZilla";
     spec.description = "Adds ability to managing tabs and windows";
-    spec.version = "0.7.0";
+    spec.version = "0.8.0";
     spec.author = "Razi Alavizadeh <s.r.alavizadeh@gmail.com>";
     spec.icon = QPixmap(":tabmanager/data/tabmanager.png");
     spec.hasSettings = true;

--- a/src/plugins/TabManager/tabmanagerplugin.cpp
+++ b/src/plugins/TabManager/tabmanagerplugin.cpp
@@ -152,7 +152,6 @@ void TabManagerPlugin::mainWindowCreated(BrowserWindow* window, bool refresh)
         }
 
         connect(window->tabWidget(), SIGNAL(currentChanged(int)), m_controller, SIGNAL(requestRefreshTree()));
-        connect(window->tabWidget(), SIGNAL(pinStateChanged(int,bool)), m_controller, SIGNAL(pinStateChanged(int,bool)));
     }
 
     if (refresh) {

--- a/src/plugins/TabManager/tabmanagerplugin.cpp
+++ b/src/plugins/TabManager/tabmanagerplugin.cpp
@@ -152,6 +152,7 @@ void TabManagerPlugin::mainWindowCreated(BrowserWindow* window, bool refresh)
         }
 
         connect(window->tabWidget(), SIGNAL(currentChanged(int)), m_controller, SIGNAL(requestRefreshTree()));
+        connect(window->tabWidget(), SIGNAL(pinStateChanged(int,bool)), m_controller, SIGNAL(requestRefreshTree()));
     }
 
     if (refresh) {

--- a/src/plugins/TabManager/tabmanagerwidget.cpp
+++ b/src/plugins/TabManager/tabmanagerwidget.cpp
@@ -750,6 +750,11 @@ void TabItem::setWebTab(WebTab* webTab)
 {
     m_webTab = webTab;
 
+    if (m_webTab->isRestored())
+        setBold(m_webTab->isCurrentTab());
+    else
+        setAsSavedTab(true);
+
     connect(m_webTab->webView()->page(), SIGNAL(audioMutedChanged(bool)), this, SLOT(updateIcon()));
     connect(m_webTab->webView()->page(), SIGNAL(loadFinished(bool)), this, SLOT(updateIcon()));
     connect(m_webTab->webView()->page(), SIGNAL(loadStarted()), this, SLOT(updateIcon()));
@@ -778,9 +783,15 @@ void TabItem::updateIcon()
         else {
             setIcon(0, QIcon(":tabmanager/data/tab-pinned.png"));
         }
+
+        if (m_webTab->isRestored())
+            setBold(m_webTab->isCurrentTab());
+        else
+            setAsSavedTab(true);
     }
     else {
         setIcon(0, QIcon(":tabmanager/data/tab-loading.png"));
+        setBold(m_webTab->isCurrentTab());
     }
 }
 
@@ -795,4 +806,14 @@ void TabItem::setBold(bool bold)
     QFont fnt(font(0));
     fnt.setBold(bold);
     setFont(0, fnt);
+
+    setAsSavedTab(false);
+}
+
+void TabItem::setAsSavedTab(bool saved)
+{
+    if (saved)
+        setData(0, Qt::UserRole + 1, QVariant(true));
+    else
+        setData(0, Qt::UserRole + 1, QVariant());
 }

--- a/src/plugins/TabManager/tabmanagerwidget.cpp
+++ b/src/plugins/TabManager/tabmanagerwidget.cpp
@@ -611,7 +611,6 @@ QTreeWidgetItem* TabManagerWidget::groupByDomainName(bool useHostName)
         // getQupZilla() instance is closing
         return nullptr;
     }
-    windows.move(currentWindowIdx, 0);
 
     QMap<QString, QTreeWidgetItem*> tabsGroupedByDomain;
 
@@ -679,6 +678,7 @@ QTreeWidgetItem* TabManagerWidget::groupByWindow()
     for (int win = 0; win < windows.count(); ++win) {
         BrowserWindow* mainWin = windows.at(win);
         TabItem* winItem = new TabItem(ui->treeWidget);
+        winItem->setBrowserWindow(mainWin);
         winItem->setText(0, tr("Window %1").arg(QString::number(win + 1)));
         winItem->setToolTip(0, tr("Double click to switch"));
         winItem->setBold(win == currentWindowIdx);

--- a/src/plugins/TabManager/tabmanagerwidget.cpp
+++ b/src/plugins/TabManager/tabmanagerwidget.cpp
@@ -783,7 +783,6 @@ void TabItem::setWebTab(WebTab* webTab)
     connect(m_webTab->webView()->page(), SIGNAL(loadStarted()), this, SLOT(updateIcon()));
     connect(m_webTab->webView(), SIGNAL(titleChanged(QString)), this, SLOT(setTitle(QString)));
     connect(m_webTab->webView(), SIGNAL(iconChanged(QIcon)), this, SLOT(updateIcon()));
-    connect(m_webTab, SIGNAL(pinStateChanged(bool)), this, SLOT(updateIcon()));
 }
 
 void TabItem::updateIcon()

--- a/src/plugins/TabManager/tabmanagerwidget.cpp
+++ b/src/plugins/TabManager/tabmanagerwidget.cpp
@@ -31,6 +31,7 @@
 #include "tldextractor/tldextractor.h"
 #include "tabmanagerdelegate.h"
 #include "tabcontextmenu.h"
+#include "tabbar.h"
 
 #include <QDesktopWidget>
 #include <QDialogButtonBox>
@@ -38,6 +39,7 @@
 #include <QDialog>
 #include <QTimer>
 #include <QLabel>
+#include <QMimeData>
 
 TLDExtractor* TabManagerWidget::s_tldExtractor = 0;
 
@@ -58,6 +60,7 @@ TabManagerWidget::TabManagerWidget(BrowserWindow* mainClass, QWidget* parent, bo
     }
 
     ui->setupUi(this);
+    ui->treeWidget->setSelectionMode(QTreeWidget::SingleSelection);
     ui->treeWidget->setUniformRowHeights(true);
     ui->treeWidget->setColumnCount(2);
     ui->treeWidget->header()->hide();
@@ -84,6 +87,7 @@ TabManagerWidget::TabManagerWidget(BrowserWindow* mainClass, QWidget* parent, bo
     connect(ui->filterBar, SIGNAL(textChanged(QString)), this, SLOT(filterChanged(QString)));
     connect(ui->treeWidget, SIGNAL(itemClicked(QTreeWidgetItem*,int)), this, SLOT(onItemActivated(QTreeWidgetItem*,int)));
     connect(ui->treeWidget, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(customContextMenuRequested(QPoint)));
+    connect(ui->treeWidget, SIGNAL(requestRefreshTree()), this, SLOT(delayedRefreshTree()));
 }
 
 TabManagerWidget::~TabManagerWidget()
@@ -526,9 +530,31 @@ void TabManagerWidget::closeSelectedTabs(const QHash<BrowserWindow*, WebTab*> &t
     }
 }
 
+static void detachTabsTo(BrowserWindow* targetWindow, const QHash<BrowserWindow*, WebTab*> &tabsHash)
+{
+    const QList<BrowserWindow*> &windows = tabsHash.uniqueKeys();
+    foreach (BrowserWindow* mainWindow, windows) {
+        const QList<WebTab*> &tabs = tabsHash.values(mainWindow);
+        foreach (WebTab* webTab, tabs) {
+            mainWindow->tabWidget()->locationBars()->removeWidget(webTab->locationBar());
+
+            QObject::disconnect(webTab->webView(), SIGNAL(wantsCloseTab(int)), mainWindow->tabWidget(), SLOT(closeTab(int)));
+            QObject::disconnect(webTab->webView(), SIGNAL(changed()), mainWindow->tabWidget(), SIGNAL(changed()));
+            QObject::disconnect(webTab->webView(), SIGNAL(ipChanged(QString)), mainWindow->ipLabel(), SLOT(setText(QString)));
+
+            webTab->detach();
+            if (mainWindow && mainWindow->tabWidget()->count() == 0) {
+                mainWindow->close();
+                mainWindow = 0;
+            }
+
+            targetWindow->tabWidget()->addView(webTab);
+        }
+    }
+}
+
 void TabManagerWidget::detachSelectedTabs(const QHash<BrowserWindow*, WebTab*> &tabsHash)
 {
-    // TODO: use TabWidget::detachTab()
     if (tabsHash.isEmpty() ||
             (tabsHash.uniqueKeys().size() == 1 &&
              tabsHash.size() == tabsHash.keys().at(0)->tabWidget()->count())) {
@@ -538,25 +564,7 @@ void TabManagerWidget::detachSelectedTabs(const QHash<BrowserWindow*, WebTab*> &
     BrowserWindow* newWindow = mApp->createWindow(Qz::BW_OtherRestoredWindow);
     newWindow->move(mApp->desktop()->availableGeometry(this).topLeft() + QPoint(30, 30));
 
-    const QList<BrowserWindow*> &windows = tabsHash.uniqueKeys();
-    foreach (BrowserWindow* mainWindow, windows) {
-        const QList<WebTab*> &tabs = tabsHash.values(mainWindow);
-        foreach (WebTab* webTab, tabs) {
-            mainWindow->tabWidget()->locationBars()->removeWidget(webTab->locationBar());
-
-            disconnect(webTab->webView(), SIGNAL(wantsCloseTab(int)), mainWindow->tabWidget(), SLOT(closeTab(int)));
-            disconnect(webTab->webView(), SIGNAL(changed()), mainWindow->tabWidget(), SIGNAL(changed()));
-            disconnect(webTab->webView(), SIGNAL(ipChanged(QString)), mainWindow->ipLabel(), SLOT(setText(QString)));
-
-            webTab->detach();
-            if (mainWindow && mainWindow->tabWidget()->count() == 0) {
-                mainWindow->close();
-                mainWindow = 0;
-            }
-
-            newWindow->tabWidget()->addView(webTab);
-        }
-    }
+    detachTabsTo(newWindow, tabsHash);
 }
 
 bool TabManagerWidget::bookmarkSelectedTabs(const QHash<BrowserWindow*, WebTab*> &tabsHash)
@@ -628,7 +636,7 @@ QTreeWidgetItem* TabManagerWidget::groupByDomainName(bool useHostName)
             QString domain = domainFromUrl(webTab->url(), useHostName);
 
             if (!tabsGroupedByDomain.contains(domain)) {
-                TabItem* groupItem = new TabItem(ui->treeWidget, 0, false);
+                TabItem* groupItem = new TabItem(ui->treeWidget, false, false, 0, false);
                 groupItem->setTitle(domain);
                 groupItem->setBold(true);
 
@@ -637,7 +645,7 @@ QTreeWidgetItem* TabManagerWidget::groupByDomainName(bool useHostName)
 
             QTreeWidgetItem* groupItem = tabsGroupedByDomain.value(domain);
 
-            TabItem* tabItem = new TabItem(ui->treeWidget, groupItem);
+            TabItem* tabItem = new TabItem(ui->treeWidget, false, true, groupItem);
             tabItem->setBrowserWindow(mainWin);
             tabItem->setWebTab(webTab);
 
@@ -677,7 +685,7 @@ QTreeWidgetItem* TabManagerWidget::groupByWindow()
 
     for (int win = 0; win < windows.count(); ++win) {
         BrowserWindow* mainWin = windows.at(win);
-        TabItem* winItem = new TabItem(ui->treeWidget);
+        TabItem* winItem = new TabItem(ui->treeWidget, true, false);
         winItem->setBrowserWindow(mainWin);
         winItem->setText(0, tr("Window %1").arg(QString::number(win + 1)));
         winItem->setToolTip(0, tr("Double click to switch"));
@@ -691,7 +699,7 @@ QTreeWidgetItem* TabManagerWidget::groupByWindow()
                 m_webPage = 0;
                 continue;
             }
-            TabItem* tabItem = new TabItem(ui->treeWidget, winItem);
+            TabItem* tabItem = new TabItem(ui->treeWidget, true, true, winItem);
             tabItem->setBrowserWindow(mainWin);
             tabItem->setWebTab(webTab);
 
@@ -720,14 +728,29 @@ BrowserWindow* TabManagerWidget::getQupZilla()
     }
 }
 
-TabItem::TabItem(QTreeWidget* treeWidget, QTreeWidgetItem* parent, bool addToTree)
+TabItem::TabItem(QTreeWidget* treeWidget, bool supportDrag, bool isTab, QTreeWidgetItem* parent, bool addToTree)
     : QObject()
     , QTreeWidgetItem(addToTree ? (parent ? parent : treeWidget->invisibleRootItem()) : 0, 1)
     , m_treeWidget(treeWidget)
+    , m_isTab(isTab)
     , m_window(0)
     , m_webTab(0)
 {
-    setFlags(flags() | (parent ? Qt::ItemIsUserCheckable : Qt::ItemIsUserCheckable | Qt::ItemIsTristate));
+    Qt::ItemFlags flgs = flags() | (parent ? Qt::ItemIsUserCheckable : Qt::ItemIsUserCheckable | Qt::ItemIsTristate);
+
+    if (supportDrag) {
+        if (isTab) {
+            flgs |= Qt::ItemIsDragEnabled | Qt::ItemNeverHasChildren;
+            flgs &= ~Qt::ItemIsDropEnabled;
+        }
+        else {
+            flgs |= Qt::ItemIsDropEnabled;
+            flgs &= ~Qt::ItemIsDragEnabled;
+        }
+    }
+
+    setFlags(flgs);
+
     setCheckState(0, Qt::Unchecked);
 }
 
@@ -816,4 +839,120 @@ void TabItem::setAsSavedTab(bool saved)
         setData(0, Qt::UserRole + 1, QVariant(true));
     else
         setData(0, Qt::UserRole + 1, QVariant());
+}
+
+bool TabItem::isTab() const
+{
+    return m_isTab;
+}
+
+TabTreeWidget::TabTreeWidget(QWidget *parent)
+    : QTreeWidget(parent)
+{
+    setDragEnabled(true);
+    setAcceptDrops(true);
+    viewport()->setAcceptDrops(true);
+    setDropIndicatorShown(true);
+
+    invisibleRootItem()->setFlags(invisibleRootItem()->flags() & ~Qt::ItemIsDropEnabled);
+}
+
+Qt::DropActions TabTreeWidget::supportedDropActions() const
+{
+    return Qt::MoveAction | Qt::CopyAction;
+}
+
+#define MIMETYPE QLatin1String("application/qupzilla.tabs")
+
+QStringList TabTreeWidget::mimeTypes() const
+{
+    QStringList types;
+    types.append(MIMETYPE);
+    return types;
+}
+
+QMimeData *TabTreeWidget::mimeData(const QList<QTreeWidgetItem*> items) const
+{
+    QMimeData* mimeData = new QMimeData();
+    QByteArray encodedData;
+
+    QDataStream stream(&encodedData, QIODevice::WriteOnly);
+
+    if (items.size() > 0) {
+        TabItem* tabItem = static_cast<TabItem*>(items.at(0));
+        if (!tabItem || !tabItem->isTab())
+            return 0;
+
+        stream << (quintptr) tabItem->window() << (quintptr) tabItem->webTab();
+
+        mimeData->setData(MIMETYPE, encodedData);
+
+        return mimeData;
+    }
+
+    return 0;
+}
+
+bool TabTreeWidget::dropMimeData(QTreeWidgetItem *parent, int index, const QMimeData *data, Qt::DropAction action)
+{
+    if (action == Qt::IgnoreAction) {
+        return true;
+    }
+
+    TabItem* parentItem = static_cast<TabItem*>(parent);
+
+    if (!data->hasFormat(MIMETYPE) || !parentItem) {
+        return false;
+    }
+
+    Q_ASSERT(!parentItem->isTab());
+
+    BrowserWindow* targetWindow = parentItem->window();
+
+    QByteArray encodedData = data->data(MIMETYPE);
+    QDataStream stream(&encodedData, QIODevice::ReadOnly);
+
+    if (!stream.atEnd()) {
+        quintptr webTabPtr;
+        quintptr windowPtr;
+
+        stream >> windowPtr >> webTabPtr;
+
+        WebTab* webTab = (WebTab*) webTabPtr;
+        BrowserWindow* window = (BrowserWindow*) windowPtr;
+
+        if (window == targetWindow) {
+            if (index > 0 && webTab->tabIndex() < index)
+                --index;
+
+            if (webTab->isPinned() && index >= targetWindow->tabWidget()->pinnedTabsCount())
+                index = targetWindow->tabWidget()->pinnedTabsCount() - 1;
+
+            if (!webTab->isPinned() && index < targetWindow->tabWidget()->pinnedTabsCount())
+                index = targetWindow->tabWidget()->pinnedTabsCount();
+
+            if (index != webTab->tabIndex()) {
+                targetWindow->tabWidget()->tabBar()->moveTab(webTab->tabIndex(), index);
+
+                if (!webTab->isCurrentTab())
+                    emit requestRefreshTree();
+            }
+            else {
+                return false;
+            }
+        }
+        else if (!webTab->isPinned()) {
+            QHash<BrowserWindow*, WebTab*> tabsHash;
+            tabsHash.insert(window, webTab);
+
+            detachTabsTo(targetWindow, tabsHash);
+
+            if (index < targetWindow->tabWidget()->pinnedTabsCount())
+                index = targetWindow->tabWidget()->pinnedTabsCount();
+
+            targetWindow->tabWidget()->tabBar()->moveTab(webTab->tabIndex(), index);
+        }
+    }
+
+    return true;
 }

--- a/src/plugins/TabManager/tabmanagerwidget.cpp
+++ b/src/plugins/TabManager/tabmanagerwidget.cpp
@@ -732,9 +732,9 @@ TabItem::TabItem(QTreeWidget* treeWidget, bool supportDrag, bool isTab, QTreeWid
     : QObject()
     , QTreeWidgetItem(addToTree ? (parent ? parent : treeWidget->invisibleRootItem()) : 0, 1)
     , m_treeWidget(treeWidget)
-    , m_isTab(isTab)
     , m_window(0)
     , m_webTab(0)
+    , m_isTab(isTab)
 {
     Qt::ItemFlags flgs = flags() | (parent ? Qt::ItemIsUserCheckable : Qt::ItemIsUserCheckable | Qt::ItemIsTristate);
 

--- a/src/plugins/TabManager/tabmanagerwidget.h
+++ b/src/plugins/TabManager/tabmanagerwidget.h
@@ -35,6 +35,23 @@ class WebTab;
 class WebView;
 class TLDExtractor;
 
+class TabTreeWidget : public QTreeWidget
+{
+    Q_OBJECT
+
+public:
+    TabTreeWidget(QWidget* parent = 0);
+
+    Qt::DropActions supportedDropActions() const;
+    QStringList mimeTypes() const;
+    QMimeData* mimeData(const QList<QTreeWidgetItem*> items) const;
+    bool dropMimeData(QTreeWidgetItem *parent, int index, const QMimeData *data, Qt::DropAction action);
+
+signals:
+    void requestRefreshTree();
+
+};
+
 class TabManagerWidget : public QWidget
 {
     Q_OBJECT
@@ -102,13 +119,15 @@ class TabItem : public QObject, public QTreeWidgetItem
     Q_OBJECT
 
 public:
-    TabItem(QTreeWidget* treeWidget, QTreeWidgetItem* parent = 0, bool addToTree = true);
+    TabItem(QTreeWidget* treeWidget, bool supportDrag = true, bool isTab = true, QTreeWidgetItem* parent = 0, bool addToTree = true);
 
     BrowserWindow* window() const;
     void setBrowserWindow(BrowserWindow* window);
 
     WebTab* webTab() const;
     void setWebTab(WebTab* webTab);
+
+    bool isTab() const;
 
 public slots:
     void updateIcon();
@@ -120,6 +139,7 @@ private:
     QTreeWidget* m_treeWidget;
     BrowserWindow* m_window;
     WebTab* m_webTab;
+    bool m_isTab;
 };
 
 #endif // TABMANAGERWIDGET_H

--- a/src/plugins/TabManager/tabmanagerwidget.h
+++ b/src/plugins/TabManager/tabmanagerwidget.h
@@ -68,8 +68,8 @@ private:
     };
 
     QTreeWidgetItem* createEmptyItem(QTreeWidgetItem* parent = 0, bool addToTree = true);
-    void groupByDomainName(bool useHostName = false);
-    void groupByWindow();
+    QTreeWidgetItem* groupByDomainName(bool useHostName = false);
+    QTreeWidgetItem* groupByWindow();
     BrowserWindow* getQupZilla();
 
     void makeWebViewConnections(WebView *view);

--- a/src/plugins/TabManager/tabmanagerwidget.h
+++ b/src/plugins/TabManager/tabmanagerwidget.h
@@ -114,6 +114,7 @@ public slots:
     void updateIcon();
     void setTitle(const QString& title);
     void setBold(bool bold);
+    void setAsSavedTab(bool saved);
 
 private:
     QTreeWidget* m_treeWidget;

--- a/src/plugins/TabManager/tabmanagerwidget.h
+++ b/src/plugins/TabManager/tabmanagerwidget.h
@@ -21,6 +21,7 @@
 #include <QWidget>
 #include <QPointer>
 #include <QHash>
+#include <QTreeWidgetItem>
 
 namespace Ui
 {
@@ -61,18 +62,9 @@ public slots:
     void changeGroupType();
 
 private:
-    enum TabDataRole {
-        WebTabPointerRole = Qt::UserRole + 10,
-        QupZillaPointerRole = Qt::UserRole + 20,
-        UrlRole = Qt::UserRole + 30
-    };
-
-    QTreeWidgetItem* createEmptyItem(QTreeWidgetItem* parent = 0, bool addToTree = true);
     QTreeWidgetItem* groupByDomainName(bool useHostName = false);
     QTreeWidgetItem* groupByWindow();
     BrowserWindow* getQupZilla();
-
-    void makeWebViewConnections(WebView *view);
 
     Ui::TabManagerWidget* ui;
     QPointer<BrowserWindow> p_QupZilla;
@@ -103,6 +95,30 @@ protected:
 signals:
     void showSideBySide();
     void groupTypeChanged(TabManagerWidget::GroupType);
+};
+
+class TabItem : public QObject, public QTreeWidgetItem
+{
+    Q_OBJECT
+
+public:
+    TabItem(QTreeWidget* treeWidget, QTreeWidgetItem* parent = 0, bool addToTree = true);
+
+    BrowserWindow* window() const;
+    void setBrowserWindow(BrowserWindow* window);
+
+    WebTab* webTab() const;
+    void setWebTab(WebTab* webTab);
+
+public slots:
+    void updateIcon();
+    void setTitle(const QString& title);
+    void setBold(bool bold);
+
+private:
+    QTreeWidget* m_treeWidget;
+    BrowserWindow* m_window;
+    WebTab* m_webTab;
 };
 
 #endif // TABMANAGERWIDGET_H

--- a/src/plugins/TabManager/tabmanagerwidget.ui
+++ b/src/plugins/TabManager/tabmanagerwidget.ui
@@ -33,7 +33,7 @@
     <widget class="LineEdit" name="filterBar"/>
    </item>
    <item>
-    <widget class="QTreeWidget" name="treeWidget">
+    <widget class="TabTreeWidget" name="treeWidget">
      <attribute name="headerVisible">
       <bool>false</bool>
      </attribute>
@@ -51,6 +51,11 @@
    <class>LineEdit</class>
    <extends>QLineEdit</extends>
    <header>lineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>TabTreeWidget</class>
+   <extends>QTreeWidget</extends>
+   <header>tabmanagerwidget.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/plugins/TabManager/tabmanagerwidgetcontroller.cpp
+++ b/src/plugins/TabManager/tabmanagerwidgetcontroller.cpp
@@ -1,6 +1,6 @@
 /* ============================================================
 * TabManager plugin for QupZilla
-* Copyright (C) 2013  S. Razi Alavizadeh <s.r.alavizadeh@gmail.com>
+* Copyright (C) 2013-2017  S. Razi Alavizadeh <s.r.alavizadeh@gmail.com>
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -122,7 +122,6 @@ TabManagerWidget* TabManagerWidgetController::createTabManagerWidget(BrowserWind
 
     connect(tabManagerWidget, SIGNAL(groupTypeChanged(TabManagerWidget::GroupType)), this, SLOT(setGroupType(TabManagerWidget::GroupType)));
     connect(this, SIGNAL(requestRefreshTree(WebPage*)), tabManagerWidget, SLOT(delayedRefreshTree(WebPage*)));
-    connect(this, SIGNAL(pinStateChanged(int,bool)), tabManagerWidget, SLOT(delayedRefreshTree()));
 
     emit requestRefreshTree();
 

--- a/src/plugins/TabManager/tabmanagerwidgetcontroller.h
+++ b/src/plugins/TabManager/tabmanagerwidgetcontroller.h
@@ -1,6 +1,6 @@
 /* ============================================================
 * TabManager plugin for QupZilla
-* Copyright (C) 2013  S. Razi Alavizadeh <s.r.alavizadeh@gmail.com>
+* Copyright (C) 2013-2017  S. Razi Alavizadeh <s.r.alavizadeh@gmail.com>
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -60,7 +60,6 @@ private:
 
 signals:
     void requestRefreshTree(WebPage* p = 0);
-    void pinStateChanged(int index, bool pinned);
 };
 
 #endif // TABMANAGERWIDGETCONTROLLER_H


### PR DESCRIPTION
1- Add tab context-menu to item context-menu.
2- Scroll to the current item.
3- Use a different color for non-loaded tabs.
4- Support moving tabs by drag-n-drop (just in `Group by Window` mode).

~~`Known issue:` Draging a tab between non-loaded tabs force them to load.~~
`Update:` The known issue was fixed by adb54dcfcc2f5ac24bb41d428006004956617bac