### PR TITLE
Mac: Revert #2184 for Qt 5.9.1+

### DIFF
--- a/mac/macdeploy.sh
+++ b/mac/macdeploy.sh
@@ -13,7 +13,6 @@ MACDEPLOYQT=$1
 QTDIR="`dirname $MACDEPLOYQT`/.."
 LIBRARY_NAME="libQupZilla.2.dylib"
 PLUGINS="QupZilla.app/Contents/Resources/plugins"
-QTPLUGINS="QupZilla.app/Contents/PlugIns"
 
 # cd to directory with bundle
 test -d bin || cd ..
@@ -34,21 +33,6 @@ for plugin in $PLUGINS/*.dylib
 do
  install_name_tool -change $LIBRARY_NAME @executable_path/$LIBRARY_NAME $plugin
 done
-
-# copy known, missing, Qt native library plugins into bundle
-#
-# See:
-#  *  http://code.qt.io/cgit/qt/qttools.git/tree/src/macdeployqt/shared/shared.cpp#n1044
-#
-mkdir -p $QTPLUGINS
-
-FILE="$QTDIR/plugins/iconengines/libqsvgicon.dylib"
-if [ -f "$FILE" ]; then
- cp $FILE $QTPLUGINS/
-else
- echo "$FILE: No such file"
- exit 1
-fi
 
 # run macdeployqt
 $MACDEPLOYQT QupZilla.app -qmldir=$PWD/../src/lib/data/data


### PR DESCRIPTION
* Now that upstream Qt has support for this back out the changes.

NOTE(S)
* Please note that users with Qt 5.9.0 and earlier on MacOS the bug will reappear... so minimum Qt build should be 5.9.1 if those icons in the dropdown menus are wanted

Ref(s):
* https://github.com/QupZilla/qupzilla/pull/2184#issuecomment-308790083