### PR TITLE
Version bump Travis CI OS X version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: ccache
 matrix:
   include:
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9
 
 env:
   - QT=qt58


### PR DESCRIPTION
* Current release is OS X 10.12.6 *(Sierra)* with Xcode 9.0 *(Sep 21, 2017)*
* Successful make, bundle, and open with 4c3ef116045e1e8f63427330337dc05b3bea9e12 and Qt 5.9.2 release Unified Installer installation.

Ref:
* https://docs.travis-ci.com/user/reference/osx/

Note(s):
* Xcode 9.1 not available in the App Store yet... so not sure how Travis CI is getting this.