### PR TITLE
Clearing correct local storage directory

### DIFF
--- a/src/lib/other/clearprivatedata.cpp
+++ b/src/lib/other/clearprivatedata.cpp
@@ -68,7 +68,7 @@ void ClearPrivateData::clearLocalStorage()
 {
     const QString profile = DataPaths::currentProfilePath();
 
-    QzTools::removeDir(profile + "/LocalStorage");
+    QzTools::removeDir(profile + "/Local Storage");
 }
 
 void ClearPrivateData::clearWebDatabases()


### PR DESCRIPTION
Qt uses a 'Local Storage' directory to store web contents
whereas QupZilla tries to delete 'LocalStorage' directory
when the 'Delete locally stored content' option is set.

Closes #2472