### PR TITLE
Version bump Travis CI OS X version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: ccache
 matrix:
   include:
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode9.1
 
 env:
   - QT=qt58


### PR DESCRIPTION
* Current release is OS X 10.12.6 *(Sierra)* with Xcode 9.1 Build 9B55 *(Nov 1, 2017)*
* Successful make, bundle, and open with 4c2a114 and Qt 5.9.2 release Unified Installer installation.

Ref:
* https://docs.travis-ci.com/user/reference/osx/