### PR TITLE
linux: add 'StartupWMClass' to desktop file

### DIFF
--- a/linux/applications/org.qupzilla.QupZilla.desktop
+++ b/linux/applications/org.qupzilla.QupZilla.desktop
@@ -78,6 +78,7 @@ GenericName[fa]=مرورگر وب
 GenericName[ar]=متصفح وِب
 GenericName[fi]=WWW-selain
 Exec=qupzilla %u
+StartupWMClass=QupZilla
 MimeType=text/html;application/xhtml+xml;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;application/x-mimearchive;
 Terminal=false
 Actions=NewTab;NewWindow;PrivateBrowsing;


### PR DESCRIPTION
This fixes various system integration things for when WM_CLASS and
WM_NAME don't match, some desktop enviroments handle this
better than others. This fixes:

* The application appearing twice in docks
* No pin to panel option shown in Budgie Desktop
* The themed icon not being used in certain situations.

Signed-off-by: Joey Riches <josephriches@gmail.com>