### PR TITLE
Default screenshot in appdata does not exist.

### DIFF
--- a/linux/appdata/org.qupzilla.QupZilla.appdata.xml
+++ b/linux/appdata/org.qupzilla.QupZilla.appdata.xml
@@ -17,7 +17,7 @@
   </p>
  </description>
  <screenshots>
-  <screenshot type="default" width="864" height="567">https://www.qupzilla.com/screens/gnome.png</screenshot>
+  <screenshot type="default" width="871" height="568">https://www.qupzilla.com/screens/gnome_window.png</screenshot>
   <screenshot width="948" height="638">https://www.qupzilla.com/screens/kde_window.png</screenshot>
   <screenshot width="864" height="567">https://www.qupzilla.com/screens/dial_gnome.png</screenshot>
   <screenshot width="944" height="633">https://www.qupzilla.com/screens/kde_speeddial.png</screenshot>


### PR DESCRIPTION
The default screenshot in appdata file (https://www.qupzilla.com/screens/gnome.png) does not exist. Redirects to https://www.qupzilla.com/home.