### PR TITLE
Use new AppData directory instead of legacy.

### DIFF
--- a/linux/appdata/org.qupzilla.QupZilla.appdata.xml
+++ b/linux/appdata/org.qupzilla.QupZilla.appdata.xml
@@ -17,7 +17,7 @@
   </p>
  </description>
  <screenshots>
-  <screenshot type="default" width="864" height="567">https://www.qupzilla.com/screens/gnome.png</screenshot>
+  <screenshot type="default" width="871" height="568">https://www.qupzilla.com/screens/gnome_window.png</screenshot>
   <screenshot width="948" height="638">https://www.qupzilla.com/screens/kde_window.png</screenshot>
   <screenshot width="864" height="567">https://www.qupzilla.com/screens/dial_gnome.png</screenshot>
   <screenshot width="944" height="633">https://www.qupzilla.com/screens/kde_speeddial.png</screenshot>

--- a/src/install.pri
+++ b/src/install.pri
@@ -47,7 +47,7 @@ mac {
     bashcompletion.path = $$share_folder/bash-completion/completions
 
     appdata.files = $$PWD/../linux/appdata/org.qupzilla.QupZilla.appdata.xml
-    appdata.path = $$share_folder/appdata
+    appdata.path = $$share_folder/metainfo
 
 
     INSTALLS += target target1 target2 target3


### PR DESCRIPTION
Probably someone will contact you from Debian or Fedora at some point for this minor issue. The new directory for appdata is now /usr/share/metainfo. Refs:
https://fedoraproject.org/wiki/Packaging:AppData
https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps
https://wiki.debian.org/AppStream/Guidelines