### PR TITLE
Version bump Travis CI OS X version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: ccache
 matrix:
   include:
     - os: osx
-      osx_image: xcode9.1
+      osx_image: xcode9.2
 
 env:
   - QT=qt58


### PR DESCRIPTION
* Current release is OS X 10.13.2 *(High Sierra)* with Xcode 9.2 Build 9C40b *(Dec 5, 2017)*
* Successful make, bundle, and open with 81bb81c and Qt 5.10.0 release Unified Installer installation.

NOTE:
* .dmg missing QupZilla icon on make *(bundle technically)*

Ref:
* https://docs.travis-ci.com/user/reference/osx/