### PR TITLE
removed unnecessary cursor:pointer from the body of speeddial

### DIFF
--- a/src/lib/data/html/speeddial.html
+++ b/src/lib/data/html/speeddial.html
@@ -13,7 +13,6 @@ body {
     font-family: sans-serif;
     color: #eaeaea;
     direction: %DIRECTION%;
-    cursor: pointer;
 }
 
 ::-webkit-scrollbar {
@@ -40,7 +39,6 @@ body * {
     font-size: 100%;
     line-height: 1.6;
     margin: 0;
-    cursor: pointer;
 }
 
 .add {
@@ -66,11 +64,13 @@ body * {
 .add:hover {
     background-color: rgba(0,0,0, 0.5);
     box-shadow: 0 0 1px 2px rgba(0,175,255, 0.5);
+    cursor: pointer;
 }
 
 .sett:hover {
     background-color: rgba(0,0,0, 0.5);
     box-shadow: 0 0 1px 2px rgba(0,175,255, 0.5);
+    cursor: pointer;
 }
 
 #quickdial {
@@ -385,6 +385,7 @@ input[type=button]:hover, input[type=text]:hover, select:hover {
     box-shadow: 0 0 1px 2px rgba(0,175,255, 0.8);
     background: rgba(0,175,255, 0.3);
     transition: 0.1s;
+    cursor: pointer;
 }
 
 input[type=button]:active, select:active {
@@ -471,6 +472,7 @@ input[type=checkbox] {
 .checkbox label:hover {
     box-shadow: 0 0 1px 2px rgba(0,175,255, 0.8);
     transition: 0.2s;
+    cursor: pointer;
 }
 
 .checkbox label:after {


### PR DESCRIPTION
The current speed dial of Qupzilla shows cursor as pointer even when there is no speeddial box under it. This creates a consufion of a link there sometimes. - So I removed that preserving "cursor:pointer" on other elements