### PR TITLE
Tabs drag/drop into the same window

### DIFF
--- a/src/lib/tabwidget/tabbar.cpp
+++ b/src/lib/tabwidget/tabbar.cpp
@@ -642,7 +642,7 @@ void TabBar::dragMoveEvent(QDragMoveEvent *event)
     const int index = tabAt(event->pos());
     const QMimeData* mime = event->mimeData();
 
-    if (index == -1 || (mime->hasFormat(MIMETYPE) && event->source() == this)) {
+    if (index == -1) {
         ComboTabBar::dragMoveEvent(event);
         return;
     }
@@ -679,10 +679,6 @@ void TabBar::dropEvent(QDropEvent* event)
     }
 
     event->acceptProposedAction();
-
-    if (mime->hasFormat(MIMETYPE) && event->source() == this) {
-        return;
-    }
 
     TabBar *sourceTabBar = qobject_cast<TabBar*>(event->source());
 

--- a/src/lib/tabwidget/tabbar.cpp
+++ b/src/lib/tabwidget/tabbar.cpp
@@ -685,6 +685,11 @@ void TabBar::dropEvent(QDropEvent* event)
     if (mime->hasFormat(MIMETYPE) && event->source() == this) {
         int index = tabAt(event->pos());
         int current = currentIndex();
+        TabDropAction action = tabDropAction(event->pos(), tabRect(index), !mime->hasFormat(MIMETYPE));
+        index = action == PrependTab ? index : index + 1;
+        if (current < index){
+            index --;
+        }
         sourceTabBar->moveTab(current, index);
         return;
     }

--- a/src/lib/tabwidget/tabbar.cpp
+++ b/src/lib/tabwidget/tabbar.cpp
@@ -684,8 +684,20 @@ void TabBar::dropEvent(QDropEvent* event)
 
     if (mime->hasFormat(MIMETYPE) && event->source() == this) {
         int index = tabAt(event->pos());
+        if (index == -1) {
+            return;
+        }
         int current = currentIndex();
+        int count = pinnedTabsCount();
         TabDropAction action = tabDropAction(event->pos(), tabRect(index), !mime->hasFormat(MIMETYPE));
+        // If pinned/unpinned tab is dragged to unpinned/pinned
+        if ((current < count) ^ (index < count)){
+            webTab(current)->togglePinned();
+            current = currentIndex();
+            if ((index > current) && (index < count)){
+                index ++;
+            }
+        }
         index = action == PrependTab ? index : index + 1;
         if (current < index){
             index --;

--- a/src/lib/tabwidget/tabbar.cpp
+++ b/src/lib/tabwidget/tabbar.cpp
@@ -682,6 +682,13 @@ void TabBar::dropEvent(QDropEvent* event)
 
     TabBar *sourceTabBar = qobject_cast<TabBar*>(event->source());
 
+    if (mime->hasFormat(MIMETYPE) && event->source() == this) {
+        int index = tabAt(event->pos());
+        int current = currentIndex();
+        sourceTabBar->moveTab(current, index);
+        return;
+    }
+
     int index = tabAt(event->pos());
     if (index == -1) {
         if (mime->hasUrls()) {


### PR DESCRIPTION
Currently drag/drop in current window just returns, instead It can function like what is done in firefox or chrome that tabs scroll (or placed) within the same window at a  new index.