### PR TITLE
fixed drop url over unrestored tabs

### DIFF
--- a/src/lib/tabwidget/tabbar.cpp
+++ b/src/lib/tabwidget/tabbar.cpp
@@ -708,8 +708,9 @@ void TabBar::dropEvent(QDropEvent* event)
             req = mApp->searchEnginesManager()->searchResult(mime->text());
         }
         if (action == SelectTab) {
-            if (tab->isRestored() && req.isValid()) {
-                tab->load(req);
+            if (req.isValid()) {
+                tab->tabActivated();
+                QTimer::singleShot(300, this,[tab, req]{tab->load(req);});
             }
         } else if (action == PrependTab || action == AppendTab) {
             const int newIndex = action == PrependTab ? index : index + 1;

--- a/src/lib/tabwidget/tabbar.cpp
+++ b/src/lib/tabwidget/tabbar.cpp
@@ -709,8 +709,7 @@ void TabBar::dropEvent(QDropEvent* event)
         }
         if (action == SelectTab) {
             if (req.isValid()) {
-                tab->tabActivated();
-                QTimer::singleShot(300, this,[tab, req]{tab->load(req);});
+                tab->load(req);
             }
         } else if (action == PrependTab || action == AppendTab) {
             const int newIndex = action == PrependTab ? index : index + 1;

--- a/src/lib/webtab/webtab.cpp
+++ b/src/lib/webtab/webtab.cpp
@@ -387,9 +387,10 @@ void WebTab::load(const LoadRequest &request)
 {
     if (!isRestored()) {
         tabActivated();
-        QTimer::singleShot(300, this, std::bind(&WebTab::load, this, request));
+        QTimer::singleShot(0, this, std::bind(&WebTab::load, this, request));
+    } else {
+        m_webView->load(request);
     }
-    m_webView->load(request);
 }
 
 void WebTab::unload()

--- a/src/lib/webtab/webtab.cpp
+++ b/src/lib/webtab/webtab.cpp
@@ -385,6 +385,10 @@ void WebTab::reload()
 
 void WebTab::load(const LoadRequest &request)
 {
+    if (!isRestored()) {
+        tabActivated();
+        QTimer::singleShot(300, this, std::bind(&WebTab::load, this, request));
+    }
     m_webView->load(request);
 }
 


### PR DESCRIPTION
If the tab is not restored then, restore it and load the dropped url