### PR TITLE
prevent duplicate bookmarks

### DIFF
--- a/src/lib/bookmarks/bookmarksmodel.cpp
+++ b/src/lib/bookmarks/bookmarksmodel.cpp
@@ -51,6 +51,10 @@ void BookmarksModel::addBookmark(BookmarkItem* parent, int row, BookmarkItem* it
     Q_ASSERT(row >= 0);
     Q_ASSERT(row <= parent->children().count());
 
+    if (m_bookmarks->isBookmarked(item->url())) {
+        return;
+    }
+
     beginInsertRows(index(parent), row, row);
     parent->addChild(item, row);
     endInsertRows();

--- a/src/lib/bookmarks/bookmarksmodel.cpp
+++ b/src/lib/bookmarks/bookmarksmodel.cpp
@@ -51,10 +51,6 @@ void BookmarksModel::addBookmark(BookmarkItem* parent, int row, BookmarkItem* it
     Q_ASSERT(row >= 0);
     Q_ASSERT(row <= parent->children().count());
 
-    if (m_bookmarks->isBookmarked(item->url())) {
-        return;
-    }
-
     beginInsertRows(index(parent), row, row);
     parent->addChild(item, row);
     endInsertRows();

--- a/src/lib/bookmarks/bookmarkstoolbar.cpp
+++ b/src/lib/bookmarks/bookmarkstoolbar.cpp
@@ -246,6 +246,9 @@ void BookmarksToolbar::dropEvent(QDropEvent* e)
     BookmarkItem* bookmark = new BookmarkItem(BookmarkItem::Url);
     bookmark->setTitle(title);
     bookmark->setUrl(url);
+    if (!BookmarksTools::allowDuplicateBookmarks(bookmark)) {
+        return;
+    }
     m_bookmarks->addBookmark(parent, bookmark);
 }
 

--- a/src/lib/bookmarks/bookmarkstoolbar.cpp
+++ b/src/lib/bookmarks/bookmarkstoolbar.cpp
@@ -237,6 +237,10 @@ void BookmarksToolbar::dropEvent(QDropEvent* e)
     QUrl url = mime->urls().at(0);
     QString title = mime->hasText() ? mime->text() : url.toEncoded(QUrl::RemoveScheme);
 
+    if (!BookmarksTools::allowDuplicateBookmarks(url)) {
+        return;
+    }
+
     BookmarkItem* parent = m_bookmarks->toolbarFolder();
     BookmarksToolbarButton* button = buttonAt(e->pos());
     if (button && button->bookmark()->isFolder()) {
@@ -246,9 +250,6 @@ void BookmarksToolbar::dropEvent(QDropEvent* e)
     BookmarkItem* bookmark = new BookmarkItem(BookmarkItem::Url);
     bookmark->setTitle(title);
     bookmark->setUrl(url);
-    if (!BookmarksTools::allowDuplicateBookmarks(bookmark)) {
-        return;
-    }
     m_bookmarks->addBookmark(parent, bookmark);
 }
 

--- a/src/lib/bookmarks/bookmarkstools.h
+++ b/src/lib/bookmarks/bookmarkstools.h
@@ -101,6 +101,9 @@ public:
 
     // Migration from Sql Bookmarks (returns true if bookmarks migrated)
     static bool migrateBookmarksIfNecessary(Bookmarks* bookmarks);
+
+    // handle duplicate bookmarks
+    static bool allowDuplicateBookmarks(BookmarkItem* item);
 };
 
 #endif // BOOKMARKSTOOLS_H

--- a/src/lib/bookmarks/bookmarkstools.h
+++ b/src/lib/bookmarks/bookmarkstools.h
@@ -102,8 +102,8 @@ public:
     // Migration from Sql Bookmarks (returns true if bookmarks migrated)
     static bool migrateBookmarksIfNecessary(Bookmarks* bookmarks);
 
-    // handle duplicate bookmarks
-    static bool allowDuplicateBookmarks(BookmarkItem* item);
+    // Handle drop of duplicate bookmarks on bookmarks toolbar
+    static bool allowDuplicateBookmarks(QUrl url);
 };
 
 #endif // BOOKMARKSTOOLS_H


### PR DESCRIPTION
context menu and drop url creates duplicate bookmarks if done more than once because there is no check if the bookmark already exists.