### PR TITLE
fixed crash with 1 tab

### DIFF
--- a/src/lib/tabwidget/tabstackedwidget.cpp
+++ b/src/lib/tabwidget/tabstackedwidget.cpp
@@ -169,9 +169,6 @@ void TabStackedWidget::keyPressEvent(QKeyEvent* event)
             m_tabBar->setFocus();
         }
     }
-    else {
-        event->ignore();
-    }
 }
 
 void TabStackedWidget::showTab(int index)

--- a/src/lib/tabwidget/tabstackedwidget.cpp
+++ b/src/lib/tabwidget/tabstackedwidget.cpp
@@ -169,6 +169,9 @@ void TabStackedWidget::keyPressEvent(QKeyEvent* event)
             m_tabBar->setFocus();
         }
     }
+    else {
+        event->accept();
+    }
 }
 
 void TabStackedWidget::showTab(int index)


### PR DESCRIPTION
when only 1 tab is present, then pressing ctrl + tab causes crash due to `event->ignore`

It seems like infinite recursion, Backtrace - (on Fedora 27, Qt 5.10)
```
(gdb) backtrace
#0  0x00007fffef7e9247 in  ()
    at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Widgets.so.5
#1  0x00007fffef7e9c35 in  ()
    at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Widgets.so.5
#2  0x00007fffef7ec713 in  ()
    at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Widgets.so.5
#3  0x00007fffef8cf49a in QMenuBar::eventFilter(QObject*, QEvent*) ()
    at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Widgets.so.5
#4  0x00007fffed5fe792 in QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) () at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Core.so.5
#5  0x00007fffef74e525 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Widgets.so.5
#6  0x00007fffef7571d6 in QApplication::notify(QObject*, QEvent*) ()
    at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Widgets.so.5
#7  0x00007fffed5fe9f8 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Core.so.5
#8  0x00007ffff78e438b in BrowserWindow::keyPressEvent(QKeyEvent*) ()
    at /lib/libQupZilla.so.2
#9  0x00007fffef78b6d7 in QWidget::event(QEvent*) ()
    at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Widgets.so.5
#10 0x00007fffef897891 in QMainWindow::event(QEvent*) ()
    at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Widgets.so.5
#11 0x00007fffef74e54c in QApplicationPrivate::notify_helper(QObject*, QEvent*) ---Type <return> to continue, or q <return> to quit---
() at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Widgets.so.5
#12 0x00007fffef7571d6 in QApplication::notify(QObject*, QEvent*) ()
    at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Widgets.so.5
#13 0x00007fffed5fe9f8 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Core.so.5
#14 0x00007ffff78e438b in BrowserWindow::keyPressEvent(QKeyEvent*) ()
    at /lib/libQupZilla.so.2
#15 0x00007fffef78b6d7 in QWidget::event(QEvent*) ()
    at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Widgets.so.5
#16 0x00007fffef897891 in QMainWindow::event(QEvent*) ()
    at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Widgets.so.5
#17 0x00007fffef74e54c in QApplicationPrivate::notify_helper(QObject*, QEvent*) () at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Widgets.so.5
#18 0x00007fffef7571d6 in QApplication::notify(QObject*, QEvent*) ()
    at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Widgets.so.5
#19 0x00007fffed5fe9f8 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Core.so.5
#20 0x00007ffff78e438b in BrowserWindow::keyPressEvent(QKeyEvent*) ()
    at /lib/libQupZilla.so.2
#21 0x00007fffef78b6d7 in QWidget::event(QEvent*) ()
    at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Widgets.so.5
#22 0x00007fffef897891 in QMainWindow::event(QEvent*) ()
    at /home/tarptaeya/Qt/5.10.0/gcc_64/lib/libQt5Widgets.so.5
---Type <return> to continue, or q <return> to quit---

``